### PR TITLE
Added SAM 2.1 models

### DIFF
--- a/src/digitalsreeni_image_annotator/sam_utils.py
+++ b/src/digitalsreeni_image_annotator/sam_utils.py
@@ -8,7 +8,11 @@ class SAMUtils:
             "SAM 2 tiny": "sam2_t.pt",
             "SAM 2 small": "sam2_s.pt",
             "SAM 2 base": "sam2_b.pt",
-            "SAM 2 large": "sam2_l.pt"
+            "SAM 2 large": "sam2_l.pt",
+            "SAM 2.1 tiny": "sam2.1_t.pt",
+            "SAM 2.1 small": "sam2.1_s.pt",
+            "SAM 2.1 base": "sam2.1_b.pt",
+            "SAM 2.1 large": "sam2.1_l.pt",
         }
         self.current_sam_model = None
         self.sam_model = None


### PR DESCRIPTION
Hello! This is an amazing project find as I've been looking for an annotation tool that supports SAM-based annotating.

This change is a small one but it adds support for the SAM 2.1 models that were [implemented in the Ultralytics python package](https://docs.ultralytics.com/models/sam-2/#how-to-use-sam-2-versatility-in-image-and-video-segmentation).

You can read more about [the full changelog here](https://encord.com/blog/sam-2.1-explained/), but the gist of the improvements for your tool specifically is that it can handle **visually similar objects** and **smaller objects** than SAM 2, allowing for more use cases in say medical segmentation.

I didn't want to override the original SAM model entries in case people wanted it for any reason. Please let me know if there's any other changes to be done.

Thank you and have a great day!