### PR TITLE
fixed bug leading to crash at interrupting SAM box drawing

### DIFF
--- a/src/digitalsreeni_image_annotator/image_label.py
+++ b/src/digitalsreeni_image_annotator/image_label.py
@@ -725,8 +725,9 @@ class ImageLabel(QLabel):
         else:
             pos = self.cursor_pos
             if self.sam_magic_wand_active and self.drawing_sam_bbox:
-                self.sam_bbox[2] = pos[0]
-                self.sam_bbox[3] = pos[1]
+                if self.sam_bbox is not None:
+                    self.sam_bbox[2] = pos[0]
+                    self.sam_bbox[3] = pos[1]
             elif self.editing_polygon:
                 self.handle_editing_move(pos)
             elif self.current_tool == "polygon" and self.current_annotation:
@@ -751,10 +752,11 @@ class ImageLabel(QLabel):
             pos = self.get_image_coordinates(event.pos())
             if event.button() == Qt.LeftButton:
                 if self.sam_magic_wand_active and self.drawing_sam_bbox:
-                    self.sam_bbox[2] = pos[0]
-                    self.sam_bbox[3] = pos[1]
-                    self.drawing_sam_bbox = False
-                    self.main_window.apply_sam_prediction()
+                    if self.sam_bbox is not None:
+                        self.sam_bbox[2] = pos[0]
+                        self.sam_bbox[3] = pos[1]
+                        self.drawing_sam_bbox = False
+                        self.main_window.apply_sam_prediction()
                 elif self.editing_polygon:
                     self.editing_point_index = None
                 elif self.current_tool == "rectangle" and self.drawing_rectangle:


### PR DESCRIPTION
This PR contains a bug fix for issue #47, which led to a crash of the annotator tool if pressing the Esc button during drawing a SAM box.
The `TypeError: 'NoneType' object does not support item assignment` resulted from a missing check, if the `sam_bbox` had actually been created (not the case if aborting).
This is solved by checking if the value `is not None`, before trying to access its indices.