### PR TITLE
Enable arrow navigation for image listbox

### DIFF
--- a/src/digitalsreeni_image_annotator/annotator_window.py
+++ b/src/digitalsreeni_image_annotator/annotator_window.py
@@ -2414,7 +2414,8 @@ class ImageAnnotator(QMainWindow):
         self.image_list_layout.addWidget(self.image_list_label)
 
         self.image_list = QListWidget()
-        self.image_list.itemClicked.connect(self.switch_image)
+        self.image_list.itemClicked.connect(self.switch_image)  # For mouse clicks
+        self.image_list.currentRowChanged.connect(lambda row: self.switch_image(self.image_list.currentItem()))  # For keyboard navigation
         self.image_list.setContextMenuPolicy(Qt.CustomContextMenu)
         self.image_list.customContextMenuRequested.connect(self.show_image_context_menu)
         self.image_list_layout.addWidget(self.image_list)

--- a/src/digitalsreeni_image_annotator/annotator_window.py
+++ b/src/digitalsreeni_image_annotator/annotator_window.py
@@ -2414,8 +2414,8 @@ class ImageAnnotator(QMainWindow):
         self.image_list_layout.addWidget(self.image_list_label)
 
         self.image_list = QListWidget()
-        self.image_list.itemClicked.connect(self.switch_image)  # For mouse clicks
-        self.image_list.currentRowChanged.connect(lambda row: self.switch_image(self.image_list.currentItem()))  # For keyboard navigation
+        self.image_list.itemClicked.connect(self.switch_image)
+        self.image_list.currentRowChanged.connect(lambda row: self.switch_image(self.image_list.currentItem()))
         self.image_list.setContextMenuPolicy(Qt.CustomContextMenu)
         self.image_list.customContextMenuRequested.connect(self.show_image_context_menu)
         self.image_list_layout.addWidget(self.image_list)


### PR DESCRIPTION
This PR resolves issue #49.

Image switching at arrow key navigation in the listbox containing the images is enabled by connecting the `currentRowChanged` signal of the `QListWidget` to the `switch_image` method.