### PR TITLE
Masks fitted to image boundaries

### DIFF
--- a/src/digitalsreeni_image_annotator/annotator_window.py
+++ b/src/digitalsreeni_image_annotator/annotator_window.py
@@ -3546,8 +3546,35 @@ class ImageAnnotator(QMainWindow):
                 QMessageBox.warning(self, "No Class Selected", "Please select a class before finishing the annotation.")
                 return
             
+            # Create a polygon from the current annotation
+            polygon = Polygon(self.image_label.current_annotation)
+            
+            # Define the image boundary as a rectangle
+            image_boundary = Polygon([(0, 0), (self.current_image.width(), 0), 
+                                       (self.current_image.width(), self.current_image.height()), 
+                                       (0, self.current_image.height())])
+            
+            # Intersect the polygon with the image boundary
+            clipped_polygon = polygon.intersection(image_boundary)
+            
+            if clipped_polygon.is_empty:
+                QMessageBox.warning(self, "Invalid Annotation", "The annotation is completely outside the image boundaries.")
+                self.image_label.clear_current_annotation()
+                self.image_label.update()
+                return
+            
+            # Convert the clipped polygon to a segmentation format
+            if isinstance(clipped_polygon, Polygon):
+                segmentation = [coord for point in clipped_polygon.exterior.coords for coord in point]
+            elif isinstance(clipped_polygon, MultiPolygon):
+                largest_polygon = max(clipped_polygon.geoms, key=lambda p: p.area)
+                segmentation = [coord for point in largest_polygon.exterior.coords for coord in point]
+            else:
+                QMessageBox.warning(self, "Invalid Annotation", "The annotation could not be processed.")
+                return
+            
             new_annotation = {
-                "segmentation": [coord for point in self.image_label.current_annotation for coord in point],
+                "segmentation": segmentation,
                 "category_id": self.class_mapping[self.current_class],
                 "category_name": self.current_class,
             }
@@ -3632,8 +3659,36 @@ class ImageAnnotator(QMainWindow):
     def finish_rectangle(self):
         if self.image_label.current_rectangle:
             x1, y1, x2, y2 = self.image_label.current_rectangle
+            
+            # Create a rectangle polygon from the annotation
+            rectangle = Polygon([(x1, y1), (x2, y1), (x2, y2), (x1, y2)])
+            
+            # Define the image boundary as a rectangle
+            image_boundary = Polygon([(0, 0), (self.current_image.width(), 0), 
+                                       (self.current_image.width(), self.current_image.height()), 
+                                       (0, self.current_image.height())])
+            
+            # Intersect the rectangle with the image boundary
+            clipped_rectangle = rectangle.intersection(image_boundary)
+            
+            if clipped_rectangle.is_empty:
+                QMessageBox.warning(self, "Invalid Annotation", "The annotation is completely outside the image boundaries.")
+                self.image_label.current_rectangle = None
+                self.image_label.update()
+                return
+            
+            # Convert the clipped rectangle to a segmentation format
+            if isinstance(clipped_rectangle, Polygon):
+                segmentation = [coord for point in clipped_rectangle.exterior.coords for coord in point]
+            elif isinstance(clipped_rectangle, MultiPolygon):
+                largest_polygon = max(clipped_rectangle.geoms, key=lambda p: p.area)
+                segmentation = [coord for point in largest_polygon.exterior.coords for coord in point]
+            else:
+                QMessageBox.warning(self, "Invalid Annotation", "The annotation could not be processed.")
+                return
+            
             new_annotation = {
-                "segmentation": [x1, y1, x2, y1, x2, y2, x1, y2],
+                "segmentation": segmentation,
                 "category_id": self.class_mapping[self.current_class],
                 "category_name": self.current_class,
             }


### PR DESCRIPTION
This PR resolves issue #32, as masks with one or more points drawn outside of the image boundary might cause issues with inference or training downstream.

#### Solution:
- to ensure that annotations are restricted to the boundaries of the displayed image, the `finish_polygon` and `finish_rectangle` methods are modified to clip the annotations to the image boundaries before saving them
- the image boundary is defined as a rectangle using the dimensions of the displayed image, then the `intersection` method is used to clip the annotation to the image boundary
- If the clipped polygon is completely empty, the annotation is discarded and a warning is shown. Else, it is converted into a segmentation format.