### PR TITLE
Filter image list by annotation status (#27) + CPU fallback for unsupported CUDA GPUs (#57)

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,14 @@ python -c "import torch; print(torch.cuda.is_available(), torch.cuda.get_device_
 
 You should see `True` and your GPU name. For other platforms or driver combinations, use the official selector at <https://pytorch.org/get-started/locally/>.
 
+#### Older NVIDIA GPUs (Pascal / Maxwell)
+
+PyTorch ≥ 2.8 wheels no longer include kernels for GPUs older than Volta (compute capability < 7.0), e.g. the GTX 10xx series (sm_61). On such cards the app detects the mismatch, warns once, and automatically runs inference on the CPU instead of crashing with `CUDA error: no kernel image is available`. To keep using the GPU, install an older PyTorch that still supports it:
+
+```bash
+pip install torch==2.4.1 torchvision==0.19.1 --index-url https://download.pytorch.org/whl/cu121
+```
+
 ## Usage
 
 1. Run the DigitalSreeni Image Annotator application:

--- a/docs/05_building_block_view.md
+++ b/docs/05_building_block_view.md
@@ -33,7 +33,8 @@ src/digitalsreeni_image_annotator/
 	├── utils.py                       # Cross-cutting utilities
 	├── core/                          # Constants, annotation utils, image utils
 	│   ├── constants.py
-	│   └── annotation_utils.py
+	│   ├── annotation_utils.py
+	│   └── torch_utils.py             # Shared torch device resolution + CPU fallback (#57)
 	├── widgets/
 	│   ├── image_label.py             # ImageLabel - canvas widget; dispatcher
 	│   ├── canvas_context.py          # CanvasContext - narrow read view (ADR-018)
@@ -208,7 +209,7 @@ the controller graph.
 | Controller | Responsibility |
 |------------|----------------|
 | `ProjectController` | `.iap` save/load, auto-save, backup/restore, missing-image prompts, window-title sync. Owns the `is_loading_project` autosave guard (load/save round-trip safety, v0.8.12). |
-| `ImageController` | Open / load / switch images and slices. TIFF + CZI loaders, the multi-dim `DimensionDialog`, the `[-ndim:]` axis-slice bug fix from the v0.9.0 era. |
+| `ImageController` | Open / load / switch images and slices. TIFF + CZI loaders, the multi-dim `DimensionDialog`, the `[-ndim:]` axis-slice bug fix from the v0.9.0 era. Image-list annotation-status filter (`image_has_annotations`, `apply_image_filter` — upstream #27). |
 | `AnnotationController` | Annotation CRUD, list sorting, highlight, edit-mode entry/exit, `finish_polygon`, `finish_rectangle`, `replace_annotations` (eraser path). Validates writes before mutating `all_annotations`. |
 | `ClassController` | Class add / delete / rename / colour / visibility. `update_slice_list_colors`, `is_class_visible`. |
 | `SAMController` | SAM box/points tool lifecycle, debounce timer, `_sam_inference_in_flight` re-entrancy guard (ADR-013), model picker. |

--- a/docs/08_crosscutting_concepts.md
+++ b/docs/08_crosscutting_concepts.md
@@ -178,6 +178,33 @@ nothing visible" in v0.9.0 manual testing.
 | SAM 2 base | ~150MB | Medium-High | Slow | ⚠️ Use with caution |
 | SAM 2 large | ~400MB | High | Very Slow | ❌ Not recommended (crashes on limited resources) |
 
+### Device Selection & Compute-Capability Fallback
+
+`torch.cuda.is_available()` is **not** sufficient to decide on GPU
+inference: it returns True for any visible CUDA device even when the
+installed torch wheels contain no kernels for its compute capability
+(torch ≥ 2.8 wheels ship sm_70+ only, so a Pascal GTX 1050 / sm_61
+passes the check but every kernel launch fails with
+`CUDA error: no kernel image is available for execution on the device`
+— upstream issue #57).
+
+All inference paths therefore resolve their device through
+`core/torch_utils.resolve_torch_device()`:
+
+- compares `torch.cuda.get_device_capability(0)` against the minimum
+  `sm_*` in `torch.cuda.get_arch_list()`; on mismatch returns
+  `("cpu", warning)` instead of `"cuda"`,
+- caches the decision process-wide (SAM, DINO and YOLO share it),
+- prints the warning once; `maybe_warn_cpu_fallback(parent)` shows it
+  as a one-time `QMessageBox` from the SAM model picker and the DINO
+  detect entry points.
+
+SAM passes `device=` explicitly on every predict call; DINO's
+`_resolve_device()` delegates to the helper (the `DINO_DEVICE` env
+override still wins); the YOLO trainer passes `device=` to
+`model.train()` and prediction. Never call bare
+`torch.cuda.is_available()` to pick a device in new code.
+
 ## Dark Mode Support
 
 ### Stylesheet Switching
@@ -499,6 +526,37 @@ if image_path is None:
 The substring fallback is kept for backward compatibility with old
 projects that may have stored normalised image names (e.g. without
 extension); new code should prefer the exact-key path.
+
+## Image List Filter — Hide Rows, Never Remove Them
+
+The image list can be filtered by annotation status (combo above the
+list; upstream issue #27, `ImageController.apply_image_filter`). The
+filter uses `setRowHidden(i, True)` and must **never** remove items:
+
+- `DINOController._navigate_to_image_or_slice` and the COCO importer
+  iterate `image_list` rows by index; removing rows would shift
+  indices under them.
+- Removing the current item fires `currentRowChanged`, which is wired
+  to `switch_image` — a filter change could silently switch the
+  displayed image. Hiding fires nothing.
+
+A non-matching row is hidden **even when it is the current selection**.
+`setRowHidden` does not change `current_image` or fire
+`currentRowChanged`, so the canvas keeps showing the worked-on image
+while its row leaves the list — e.g. the current image gains its first
+annotation under the "Without annotations" filter and disappears from
+the list, but stays on screen until the user navigates away. Keyboard
+nav skips hidden rows. (Guaranteed by
+`test_hiding_current_row_keeps_canvas_and_fires_no_switch`.)
+
+Re-apply runs from `ClassController.update_slice_list_colors()`. The
+contract: every annotation-mutation site either calls that method
+directly **or** emits `annotationsBatchSaved` (whose handler
+`_on_annotations_batch_saved` calls it). All `annotationCommitted`
+emitters follow up with `annotationsBatchSaved`
+(image_label.py / paint_tool.py), so both commit paths are covered.
+New mutation paths must keep one of those two routes — don't add
+bespoke `apply_image_filter()` call sites.
 
 ## Canvas Decoupling — Signals + CanvasContext
 

--- a/src/digitalsreeni_image_annotator/annotator_window.py
+++ b/src/digitalsreeni_image_annotator/annotator_window.py
@@ -273,6 +273,9 @@ class ImageAnnotator(QMainWindow):
     def update_image_list(self):
         return self.image_controller.update_image_list()
 
+    def apply_image_filter(self):
+        return self.image_controller.apply_image_filter()
+
     def select_class(self, index):
         return self.class_controller.select_class(index)
 

--- a/src/digitalsreeni_image_annotator/controllers/class_controller.py
+++ b/src/digitalsreeni_image_annotator/controllers/class_controller.py
@@ -96,6 +96,13 @@ class ClassController(QObject):
 
         self.mw.slice_list.repaint()
 
+        # Re-apply hook for the image-list annotation filter. Contract:
+        # every annotation-mutation site either calls this method directly
+        # or emits annotationsBatchSaved, whose handler
+        # (_on_annotations_batch_saved) calls it. New mutation paths must
+        # keep one of those two routes.
+        self.mw.image_controller.apply_image_filter()
+
     def add_class(self, class_name=None, color=None):
         if not self.mw.image_label.check_unsaved_changes():
             return

--- a/src/digitalsreeni_image_annotator/controllers/dino_controller.py
+++ b/src/digitalsreeni_image_annotator/controllers/dino_controller.py
@@ -211,6 +211,9 @@ class DINOController(QObject):
                                 "Please add at least one class with phrases.")
             return
 
+        from ..core.torch_utils import maybe_warn_cpu_fallback
+        maybe_warn_cpu_fallback(self.mw)
+
         self.mw.btn_detect_single.setEnabled(False)
         self.mw.btn_detect_batch.setEnabled(False)
 
@@ -359,6 +362,9 @@ class DINOController(QObject):
             QMessageBox.warning(self.mw, "No Classes",
                                 "Please add at least one class with phrases.")
             return
+
+        from ..core.torch_utils import maybe_warn_cpu_fallback
+        maybe_warn_cpu_fallback(self.mw)
 
         # Prevent stale temp annotations from a prior single-image review from
         # confusing the batch results handler or the DINOReviewEventFilter.

--- a/src/digitalsreeni_image_annotator/controllers/image_controller.py
+++ b/src/digitalsreeni_image_annotator/controllers/image_controller.py
@@ -89,6 +89,73 @@ class ImageController(QObject):
         self.mw.image_list.clear()
         for image_info in self.mw.all_images:
             self.mw.image_list.addItem(image_info["file_name"])
+        self.apply_image_filter()
+
+    def image_has_annotations(self, image_info):
+        """True if the image (or, for multi-dim images, any of its slices)
+        has at least one annotation."""
+
+        def _non_empty(by_class):
+            return bool(by_class) and any(by_class.values())
+
+        file_name = image_info["file_name"]
+        if _non_empty(self.mw.all_annotations.get(file_name, {})):
+            return True
+
+        if image_info.get("is_multi_slice", False):
+            base_name = os.path.splitext(file_name)[0]
+            slices = self.mw.image_slices.get(base_name)
+            if slices:
+                return any(
+                    _non_empty(self.mw.all_annotations.get(slice_name, {}))
+                    for slice_name, _ in slices
+                )
+            # Slices not extracted yet (e.g. load cancelled) — slice keys
+            # are f"{base_name}_T1_Z5_..." so a "{base_name}_" prefix match
+            # is exact enough; a bare substring match would not be. Caveat:
+            # this also matches "{base_name}_8bit" artifact keys, which
+            # redefine_dimensions deliberately excludes — acceptable here
+            # since an _8bit key with annotations still means "this image
+            # has annotations".
+            prefix = base_name + "_"
+            return any(
+                key.startswith(prefix) and _non_empty(by_class)
+                for key, by_class in self.mw.all_annotations.items()
+            )
+
+        return False
+
+    def apply_image_filter(self):
+        """Hide image-list rows that don't match the annotation-status
+        filter (upstream issue #27).
+
+        Rows are hidden via setRowHidden, never removed: other code
+        (DINO batch navigation, COCO import) iterates the list by row
+        index, and hiding fires no currentRowChanged so it cannot
+        trigger a spurious switch_image.
+
+        A non-matching row is hidden even when it is the current
+        selection — hiding does not change `current_image`, so the canvas
+        keeps showing the worked-on image while its row leaves the list
+        (e.g. the image just gained its first annotation under the
+        "Without annotations" filter). Keyboard nav skips hidden rows.
+        """
+        combo = getattr(self.mw, "image_filter_combo", None)
+        if combo is None:
+            return
+        mode = combo.currentIndex()  # 0 = all, 1 = without, 2 = with
+        if mode == 0:
+            # Default case runs on every update_slice_list_colors —
+            # keep it a plain unhide pass with no annotation scans.
+            for i in range(self.mw.image_list.count()):
+                self.mw.image_list.setRowHidden(i, False)
+            return
+        infos = {info["file_name"]: info for info in self.mw.all_images}
+        for i in range(self.mw.image_list.count()):
+            info = infos.get(self.mw.image_list.item(i).text())
+            annotated = bool(info) and self.image_has_annotations(info)
+            hide = annotated if mode == 1 else not annotated
+            self.mw.image_list.setRowHidden(i, hide)
 
     def setup_slice_list(self):
         self.mw.slice_list = QListWidget()
@@ -161,6 +228,8 @@ class ImageController(QObject):
         if first_added_item:
             self.mw.image_list.setCurrentItem(first_added_item)
             self.switch_image(first_added_item)
+
+        self.apply_image_filter()
 
         if not self.mw.is_loading_project:
             self.mw.auto_save()

--- a/src/digitalsreeni_image_annotator/controllers/sam_controller.py
+++ b/src/digitalsreeni_image_annotator/controllers/sam_controller.py
@@ -214,6 +214,10 @@ class SAMController(QObject):
 
         if model_name != "Pick a SAM Model":
             print(f"Changed SAM model to: {model_name}")
+            # One-time dialog if CUDA exists but the torch wheels can't
+            # run it (e.g. Pascal sm_61 on torch>=2.8) — upstream #57.
+            from ..core.torch_utils import maybe_warn_cpu_fallback
+            maybe_warn_cpu_fallback(self.mw)
         else:
             self.deactivate_sam_tools()
             print("SAM model unset")

--- a/src/digitalsreeni_image_annotator/core/torch_utils.py
+++ b/src/digitalsreeni_image_annotator/core/torch_utils.py
@@ -1,0 +1,95 @@
+"""
+Shared torch device selection (upstream issue #57).
+
+torch.cuda.is_available() returns True for any visible CUDA device, even
+when the installed torch wheels contain no kernels for its compute
+capability (e.g. torch >= 2.8 wheels ship sm_70+ only, so a Pascal
+GTX 1050 / sm_61 passes the availability check but every kernel launch
+dies with "CUDA error: no kernel image is available for execution on
+the device"). This module detects that mismatch up front and falls back
+to CPU with an actionable warning instead of a cryptic crash mid-inference.
+"""
+
+_cached_result = None
+
+
+def resolve_torch_device():
+    """Return ``(device, warning)``.
+
+    ``device`` is ``"cuda"`` or ``"cpu"``; ``warning`` is None or a
+    human-readable explanation of why CUDA was rejected (printed once on
+    first call). The result is cached for the process lifetime so SAM,
+    DINO and YOLO all share one decision.
+    """
+    global _cached_result
+    if _cached_result is None:
+        _cached_result = _resolve()
+        if _cached_result[1]:
+            print(f"[torch] {_cached_result[1]}")
+    return _cached_result
+
+
+def _resolve():
+    try:
+        import torch
+    except Exception:
+        return ("cpu", None)
+
+    try:
+        if not torch.cuda.is_available():
+            return ("cpu", None)
+
+        # Deliberately device-0-only: on a mixed multi-GPU box this may
+        # force CPU even though a later index is supported; the app never
+        # selects a non-default CUDA device anywhere, so index 0 is what
+        # inference would actually run on.
+        major, minor = torch.cuda.get_device_capability(0)
+        device_sm = major * 10 + minor
+        compiled_sms = _parse_arch_list(torch.cuda.get_arch_list())
+
+        if compiled_sms and device_sm < min(compiled_sms):
+            gpu = torch.cuda.get_device_name(0)
+            return (
+                "cpu",
+                f"GPU '{gpu}' (compute capability sm_{device_sm}) is not "
+                f"supported by the installed PyTorch build (compiled for "
+                f"sm_{min(compiled_sms)}+). Falling back to CPU. For GPU "
+                f"inference install an older PyTorch with support for this "
+                f"card, e.g.:\n"
+                f"  pip install torch==2.4.1 torchvision==0.19.1 "
+                f"--index-url https://download.pytorch.org/whl/cu121",
+            )
+        return ("cuda", None)
+    except Exception as e:
+        # Any probing failure: prefer a working CPU path over a crash.
+        return ("cpu", f"Could not verify CUDA compatibility ({e}); "
+                       f"falling back to CPU.")
+
+
+_warning_shown = False
+
+
+def maybe_warn_cpu_fallback(parent=None):
+    """Show the CUDA-incompatibility warning as a dialog, once per session.
+
+    No-op when the device resolved cleanly (CUDA usable, or no GPU at
+    all — running on CPU without a discrete GPU is expected and needs
+    no dialog).
+    """
+    global _warning_shown
+    _, warning = resolve_torch_device()
+    if warning is None or _warning_shown:
+        return
+    _warning_shown = True
+    from PyQt6.QtWidgets import QMessageBox
+    QMessageBox.warning(parent, "GPU not usable — running on CPU", warning)
+
+
+def _parse_arch_list(arch_list):
+    """Extract numeric sm values from e.g. ["sm_70", "sm_80", "compute_90"]."""
+    sms = []
+    for arch in arch_list:
+        prefix, _, num = arch.rpartition("_")
+        if prefix.endswith("sm") and num.isdigit():
+            sms.append(int(num))
+    return sms

--- a/src/digitalsreeni_image_annotator/dialogs/yolo_trainer.py
+++ b/src/digitalsreeni_image_annotator/dialogs/yolo_trainer.py
@@ -243,7 +243,9 @@ class YOLOTrainer(QObject):
             print(f"Training with updated YAML: {temp_yaml_path}")
             print(f"Updated YAML content: {yaml_content}")
             
-            results = self.model.train(data=str(temp_yaml_path), epochs=epochs, imgsz=imgsz)
+            from ..core.torch_utils import resolve_torch_device
+            device, _ = resolve_torch_device()
+            results = self.model.train(data=str(temp_yaml_path), epochs=epochs, imgsz=imgsz, device=device)
             return results
         finally:
             # Clear the callback
@@ -375,12 +377,10 @@ class YOLOTrainer(QObject):
     def predict(self, input_data):
         if self.model is None:
             raise ValueError("No model loaded. Please load a model first.")
-        if isinstance(input_data, str):
-            # It's a file path
-            results = self.model(input_data, task='segment', conf=self.conf_threshold, save=False, show=False)
-        elif isinstance(input_data, np.ndarray):
-            # It's a numpy array
-            results = self.model(input_data, task='segment', conf=self.conf_threshold, save=False, show=False)
+        from ..core.torch_utils import resolve_torch_device
+        device, _ = resolve_torch_device()
+        if isinstance(input_data, (str, np.ndarray)):
+            results = self.model(input_data, task='segment', conf=self.conf_threshold, save=False, show=False, device=device)
         else:
             raise ValueError("Invalid input type. Expected file path or numpy array.")
         

--- a/src/digitalsreeni_image_annotator/inference/dino_utils.py
+++ b/src/digitalsreeni_image_annotator/inference/dino_utils.py
@@ -73,15 +73,15 @@ class DINOUtils(QObject):
     # ── model lifecycle ───────────────────────────────────────────────
 
     def _resolve_device(self) -> str:
-        """Pick CUDA if available; honour DINO_DEVICE env override."""
+        """Pick CUDA if available and usable; honour DINO_DEVICE override."""
         env = os.environ.get("DINO_DEVICE")
         if env:
             return env
-        try:
-            import torch
-            return "cuda" if torch.cuda.is_available() else "cpu"
-        except Exception:
-            return "cpu"
+        # Shared helper also rejects GPUs whose compute capability the
+        # installed torch wheels can't run (upstream issue #57).
+        from ..core.torch_utils import resolve_torch_device
+        device, _ = resolve_torch_device()
+        return device
 
     def _load_model_blocking(self, model_path: str) -> None:
         """Load (cache) the Grounding DINO model for ``model_path``."""

--- a/src/digitalsreeni_image_annotator/inference/sam_utils.py
+++ b/src/digitalsreeni_image_annotator/inference/sam_utils.py
@@ -302,6 +302,7 @@ class SAMUtils(QObject):
         self.current_sam_model: str | None = None
         self._model = None  # ultralytics.SAM instance once loaded
         self._loaded_model_file: str | None = None
+        self._device: str | None = None  # resolved at model load
 
     # ── model lifecycle ────────────────────────────────────────────────
 
@@ -329,21 +330,23 @@ class SAMUtils(QObject):
     def _load_model_blocking(self, model_name: str) -> None:
         # Lazy import keeps app startup fast for users who never use SAM.
         from ultralytics import SAM
+        from ..core.torch_utils import resolve_torch_device
+
+        self._device, _ = resolve_torch_device()
         self._log_device()
         model_file = os.path.join(SAM_MODELS_DIR, MODEL_FILES[model_name])
         os.makedirs(os.path.dirname(model_file), exist_ok=True)
         self._model = SAM(model_file)
         self._loaded_model_file = model_file
 
-    @staticmethod
-    def _log_device() -> None:
+    def _log_device(self) -> None:
         try:
             import torch
-            if torch.cuda.is_available():
+            if self._device == "cuda":
                 dev = torch.cuda.get_device_name(0)
                 print(f"[SAM] Using CUDA: {torch.version.cuda} — {dev}")
             else:
-                print("[SAM] No GPU available, running on CPU")
+                print("[SAM] Running on CPU")
         except Exception:
             pass
 
@@ -406,7 +409,9 @@ class SAMUtils(QObject):
     def _sam_points_blocking(self, image_np, positive_points, negative_points):
         all_points = [positive_points + negative_points]
         all_labels = [([1] * len(positive_points)) + ([0] * len(negative_points))]
-        results = self._model(image_np, points=all_points, labels=all_labels)
+        results = self._model(
+            image_np, points=all_points, labels=all_labels, device=self._device
+        )
 
         masks = results[0].masks.data.cpu().numpy()
         confidences = results[0].boxes.conf.cpu().numpy()
@@ -438,7 +443,7 @@ class SAMUtils(QObject):
         )
 
     def _sam_bbox_blocking(self, image_np, bbox):
-        results = self._model(image_np, bboxes=[bbox])
+        results = self._model(image_np, bboxes=[bbox], device=self._device)
         res = results[0]
         if not (hasattr(res, "masks") and res.masks is not None):
             return None
@@ -481,7 +486,7 @@ class SAMUtils(QObject):
         )
 
     def _sam_batch_blocking(self, image_np, bboxes):
-        results = self._model(image_np, bboxes=bboxes)
+        results = self._model(image_np, bboxes=bboxes, device=self._device)
         res = results[0]
         if not (hasattr(res, "masks") and res.masks is not None):
             # Build a fresh dict per bbox so callers can mutate one

--- a/src/digitalsreeni_image_annotator/ui/sidebar.py
+++ b/src/digitalsreeni_image_annotator/ui/sidebar.py
@@ -319,6 +319,20 @@ def build_image_list(window):
     window.image_list_label = QLabel("Images:")
     window.image_list_layout.addWidget(window.image_list_label)
 
+    # Annotation-status filter (upstream issue #27). Index order matters:
+    # ImageController.apply_image_filter maps 0=all, 1=without, 2=with.
+    window.image_filter_combo = QComboBox()
+    window.image_filter_combo.addItem("All images")
+    window.image_filter_combo.addItem("Without annotations")
+    window.image_filter_combo.addItem("With annotations")
+    window.image_filter_combo.setToolTip(
+        "Filter the image list by annotation status"
+    )
+    window.image_filter_combo.currentIndexChanged.connect(
+        lambda _index: window.apply_image_filter()
+    )
+    window.image_list_layout.addWidget(window.image_filter_combo)
+
     window.image_list = QListWidget()
     window.image_list.itemClicked.connect(window.switch_image)
     window.image_list.currentRowChanged.connect(

--- a/tests/integration/test_image_filter_wiring.py
+++ b/tests/integration/test_image_filter_wiring.py
@@ -1,0 +1,87 @@
+"""
+Integration test for the image-filter re-apply wiring (upstream #27).
+
+The unit tests call apply_image_filter() directly; this test goes through
+the real mutation path instead: ImageLabel.annotationsBatchSaved →
+ImageAnnotator._on_annotations_batch_saved → save_current_annotations →
+ClassController.update_slice_list_colors → apply_image_filter. It is the
+test that fails if someone refactors the slice-color path and silently
+detaches the filter from annotation mutations.
+
+Constructs one full ImageAnnotator (offscreen) — deliberately, despite
+the runtime cost, because the coupling under test spans window, signals
+and three controllers.
+"""
+
+import pytest
+
+
+FILTER_WITHOUT = 1  # combo index: "Without annotations"
+FILTER_WITH = 2  # combo index: "With annotations"
+
+
+@pytest.fixture
+def window(qt_application):
+    from digitalsreeni_image_annotator.annotator_window import ImageAnnotator
+
+    w = ImageAnnotator()
+    yield w
+    w.deleteLater()
+
+
+def test_annotation_commit_path_reapplies_filter(window):
+    # Two regular images, neither annotated yet. currentRow stays -1 so
+    # the "never hide current row" exemption doesn't mask the assertion.
+    for name in ("a.png", "b.png"):
+        window.all_images.append({"file_name": name, "is_multi_slice": False})
+        window.image_list.addItem(name)
+
+    window.image_filter_combo.setCurrentIndex(FILTER_WITH)
+    assert window.image_list.isRowHidden(0)
+    assert window.image_list.isRowHidden(1)
+
+    # Simulate finishing an annotation on a.png the way the canvas does:
+    # ImageLabel holds the in-progress annotations and emits the batch
+    # finalizer signal. No direct apply_image_filter / all_annotations
+    # manipulation here — that's the point of the test.
+    window.image_file_name = "a.png"
+    window.image_label.annotations = {
+        "cell": [{"segmentation": [0, 0, 10, 0, 10, 10], "category_name": "cell"}]
+    }
+    window.image_label.annotationsBatchSaved.emit()
+
+    assert window.all_annotations["a.png"]  # save path ran
+    assert not window.image_list.isRowHidden(0)  # a.png now annotated
+    assert window.image_list.isRowHidden(1)  # b.png still hidden
+
+
+def test_hiding_current_row_keeps_canvas_and_fires_no_switch(window):
+    # Hiding the currently selected (non-matching) row must not change
+    # the displayed image or fire switch_image — the canvas stays on the
+    # worked-on image while its row leaves the list.
+    for name in ("annot.png", "plain.png"):
+        window.all_images.append({"file_name": name, "is_multi_slice": False})
+        window.image_list.addItem(name)
+    window.all_annotations["annot.png"] = {
+        "cell": [{"segmentation": [0, 0, 1, 0, 1, 1], "category_name": "cell"}]
+    }
+
+    # Pure counter (does NOT delegate to the real switch_image, which
+    # needs a loaded project): isolates whether the *filter* fires a
+    # switch. setCurrentRow below legitimately fires it once via
+    # currentRowChanged — that is product behavior and is cleared away.
+    calls = []
+    window.switch_image = lambda item: calls.append(item)
+
+    window.image_list.setCurrentRow(0)  # select the annotated image
+    sentinel = object()
+    window.current_image = sentinel
+    calls.clear()
+
+    # "Without annotations" must hide row 0 even though it is current.
+    window.image_filter_combo.setCurrentIndex(FILTER_WITHOUT)
+
+    assert window.image_list.isRowHidden(0)  # current row hidden
+    assert not window.image_list.isRowHidden(1)
+    assert window.current_image is sentinel  # canvas unchanged
+    assert calls == []  # hiding the current row fired no switch_image

--- a/tests/integration/test_smoke.py
+++ b/tests/integration/test_smoke.py
@@ -47,6 +47,7 @@ INTERNAL_MODULES = [
     # Core helpers
     "digitalsreeni_image_annotator.core.constants",
     "digitalsreeni_image_annotator.core.annotation_utils",
+    "digitalsreeni_image_annotator.core.torch_utils",
     # UI
     "digitalsreeni_image_annotator.ui.default_stylesheet",
     "digitalsreeni_image_annotator.ui.soft_dark_stylesheet",

--- a/tests/unit/test_image_filter.py
+++ b/tests/unit/test_image_filter.py
@@ -1,0 +1,149 @@
+"""
+Unit tests for the image-list annotation-status filter (upstream issue #27).
+
+Covers ImageController.image_has_annotations and apply_image_filter.
+"""
+
+import pytest
+from PyQt6.QtWidgets import QWidget, QListWidget, QComboBox
+
+from src.digitalsreeni_image_annotator.controllers.image_controller import (
+    ImageController,
+)
+
+
+FILTER_ALL = 0
+FILTER_WITHOUT = 1
+FILTER_WITH = 2
+
+
+class FakeMainWindow(QWidget):
+    """Minimal stand-in for ImageAnnotator with the state the filter reads."""
+
+
+@pytest.fixture
+def mw(qtbot):
+    window = FakeMainWindow()
+    qtbot.addWidget(window)
+    window.image_list = QListWidget(window)
+    window.image_filter_combo = QComboBox(window)
+    window.image_filter_combo.addItems(
+        ["All images", "Without annotations", "With annotations"]
+    )
+    window.all_images = []
+    window.all_annotations = {}
+    window.image_slices = {}
+    window.image_controller = ImageController(window)
+    return window
+
+
+def _add_image(mw, file_name, is_multi_slice=False):
+    mw.all_images.append(
+        {"file_name": file_name, "is_multi_slice": is_multi_slice}
+    )
+    mw.image_list.addItem(file_name)
+
+
+class TestImageHasAnnotations:
+    def test_regular_image_without_annotations(self, mw):
+        _add_image(mw, "plain.png")
+        assert not mw.image_controller.image_has_annotations(mw.all_images[0])
+
+    def test_regular_image_with_empty_class_lists(self, mw):
+        _add_image(mw, "plain.png")
+        mw.all_annotations["plain.png"] = {"cell": []}
+        assert not mw.image_controller.image_has_annotations(mw.all_images[0])
+
+    def test_regular_image_with_annotations(self, mw):
+        _add_image(mw, "plain.png")
+        mw.all_annotations["plain.png"] = {
+            "cell": [{"segmentation": [0, 0, 1, 0, 1, 1]}]
+        }
+        assert mw.image_controller.image_has_annotations(mw.all_images[0])
+
+    def test_multi_slice_with_annotated_slice(self, mw):
+        _add_image(mw, "stack.tif", is_multi_slice=True)
+        mw.image_slices["stack"] = [("stack_T1_Z1", None), ("stack_T1_Z2", None)]
+        mw.all_annotations["stack_T1_Z2"] = {
+            "cell": [{"segmentation": [0, 0, 1, 0, 1, 1]}]
+        }
+        assert mw.image_controller.image_has_annotations(mw.all_images[0])
+
+    def test_multi_slice_without_annotated_slices(self, mw):
+        _add_image(mw, "stack.tif", is_multi_slice=True)
+        mw.image_slices["stack"] = [("stack_T1_Z1", None)]
+        mw.all_annotations["stack_T1_Z1"] = {"cell": []}
+        assert not mw.image_controller.image_has_annotations(mw.all_images[0])
+
+    def test_multi_slice_prefix_fallback_when_slices_not_loaded(self, mw):
+        # Project annotations exist under slice keys, but the slices were
+        # never extracted (e.g. load cancelled) — prefix fallback applies.
+        _add_image(mw, "stack.tif", is_multi_slice=True)
+        mw.all_annotations["stack_T1_Z5_C1"] = {
+            "cell": [{"segmentation": [0, 0, 1, 0, 1, 1]}]
+        }
+        assert mw.image_controller.image_has_annotations(mw.all_images[0])
+
+    def test_multi_slice_no_substring_false_positive(self, mw):
+        # "bee" must not match keys of "honeybee" (and vice versa).
+        _add_image(mw, "bee.tif", is_multi_slice=True)
+        mw.all_annotations["honeybee_T1_Z1"] = {
+            "cell": [{"segmentation": [0, 0, 1, 0, 1, 1]}]
+        }
+        assert not mw.image_controller.image_has_annotations(mw.all_images[0])
+
+
+class TestApplyImageFilter:
+    @pytest.fixture
+    def populated(self, mw):
+        _add_image(mw, "annotated.png")
+        _add_image(mw, "empty.png")
+        mw.all_annotations["annotated.png"] = {
+            "cell": [{"segmentation": [0, 0, 1, 0, 1, 1]}]
+        }
+        # Select the annotated image so the "never hide current" rule is
+        # exercised by a dedicated test, not by accident here.
+        mw.image_list.setCurrentRow(-1)
+        return mw
+
+    def _hidden(self, mw):
+        return [
+            mw.image_list.isRowHidden(i) for i in range(mw.image_list.count())
+        ]
+
+    def test_all_images_shows_everything(self, populated):
+        populated.image_filter_combo.setCurrentIndex(FILTER_ALL)
+        populated.image_controller.apply_image_filter()
+        assert self._hidden(populated) == [False, False]
+
+    def test_without_annotations_hides_annotated(self, populated):
+        populated.image_filter_combo.setCurrentIndex(FILTER_WITHOUT)
+        populated.image_controller.apply_image_filter()
+        assert self._hidden(populated) == [True, False]
+
+    def test_with_annotations_hides_unannotated(self, populated):
+        populated.image_filter_combo.setCurrentIndex(FILTER_WITH)
+        populated.image_controller.apply_image_filter()
+        assert self._hidden(populated) == [False, True]
+
+    def test_current_row_is_hidden_when_not_matching(self, populated):
+        # The current row is not exempt: a non-matching selected image
+        # leaves the list (the canvas keeps showing it — see the wiring
+        # test for the switch_image / canvas-unchanged guarantee).
+        populated.image_list.setCurrentRow(0)  # annotated.png
+        populated.image_filter_combo.setCurrentIndex(FILTER_WITHOUT)
+        populated.image_controller.apply_image_filter()
+        assert self._hidden(populated) == [True, False]
+
+    def test_no_combo_is_a_noop(self, mw):
+        _add_image(mw, "plain.png")
+        del mw.image_filter_combo
+        mw.image_controller.apply_image_filter()  # must not raise
+        assert not mw.image_list.isRowHidden(0)
+
+    def test_switching_back_to_all_unhides(self, populated):
+        populated.image_filter_combo.setCurrentIndex(FILTER_WITH)
+        populated.image_controller.apply_image_filter()
+        populated.image_filter_combo.setCurrentIndex(FILTER_ALL)
+        populated.image_controller.apply_image_filter()
+        assert self._hidden(populated) == [False, False]

--- a/tests/unit/test_torch_utils.py
+++ b/tests/unit/test_torch_utils.py
@@ -1,0 +1,128 @@
+"""
+Unit tests for core.torch_utils device resolution (upstream issue #57).
+
+A fake `torch` module is injected into sys.modules so the tests run the
+same on machines with and without CUDA.
+"""
+
+import sys
+import types
+
+import pytest
+
+from src.digitalsreeni_image_annotator.core import torch_utils
+
+
+@pytest.fixture(autouse=True)
+def reset_cache():
+    torch_utils._cached_result = None
+    torch_utils._warning_shown = False
+    yield
+    torch_utils._cached_result = None
+    torch_utils._warning_shown = False
+
+
+@pytest.fixture
+def fake_torch(monkeypatch):
+    """Install a configurable fake torch module; returns its cuda namespace."""
+    cuda = types.SimpleNamespace(
+        is_available=lambda: False,
+        get_device_capability=lambda idx=0: (8, 6),
+        get_arch_list=lambda: ["sm_70", "sm_80", "sm_90", "compute_90"],
+        get_device_name=lambda idx=0: "Fake GPU",
+    )
+    module = types.ModuleType("torch")
+    module.cuda = cuda
+    monkeypatch.setitem(sys.modules, "torch", module)
+    return cuda
+
+
+def test_no_cuda_returns_cpu_without_warning(fake_torch):
+    assert torch_utils.resolve_torch_device() == ("cpu", None)
+
+
+def test_supported_gpu_returns_cuda(fake_torch):
+    fake_torch.is_available = lambda: True
+    assert torch_utils.resolve_torch_device() == ("cuda", None)
+
+
+def test_unsupported_pascal_gpu_falls_back_to_cpu(fake_torch):
+    fake_torch.is_available = lambda: True
+    fake_torch.get_device_capability = lambda idx=0: (6, 1)  # GTX 1050
+    device, warning = torch_utils.resolve_torch_device()
+    assert device == "cpu"
+    assert "sm_61" in warning
+    assert "sm_70" in warning
+    assert "Fake GPU" in warning
+
+
+def test_oldest_supported_capability_is_accepted(fake_torch):
+    fake_torch.is_available = lambda: True
+    fake_torch.get_device_capability = lambda idx=0: (7, 0)
+    assert torch_utils.resolve_torch_device() == ("cuda", None)
+
+
+def test_empty_arch_list_keeps_cuda(fake_torch):
+    # Defensive: if torch reports no compiled arches, don't second-guess it.
+    fake_torch.is_available = lambda: True
+    fake_torch.get_arch_list = lambda: []
+    assert torch_utils.resolve_torch_device() == ("cuda", None)
+
+
+def test_probe_failure_falls_back_to_cpu(fake_torch):
+    fake_torch.is_available = lambda: True
+
+    def boom(idx=0):
+        raise RuntimeError("driver mismatch")
+
+    fake_torch.get_device_capability = boom
+    device, warning = torch_utils.resolve_torch_device()
+    assert device == "cpu"
+    assert "driver mismatch" in warning
+
+
+def test_missing_torch_returns_cpu(monkeypatch):
+    monkeypatch.setitem(sys.modules, "torch", None)  # import torch → fails
+    assert torch_utils.resolve_torch_device() == ("cpu", None)
+
+
+def test_result_is_cached(fake_torch):
+    fake_torch.is_available = lambda: True
+    assert torch_utils.resolve_torch_device() == ("cuda", None)
+    # Changing the fake afterwards must not change the cached decision.
+    fake_torch.is_available = lambda: False
+    assert torch_utils.resolve_torch_device() == ("cuda", None)
+
+
+def test_parse_arch_list():
+    assert torch_utils._parse_arch_list(
+        ["sm_70", "sm_80", "compute_90", "garbage", "sm_xx"]
+    ) == [70, 80]
+
+
+def test_warning_dialog_shown_once(fake_torch, monkeypatch, qt_application):
+    fake_torch.is_available = lambda: True
+    fake_torch.get_device_capability = lambda idx=0: (6, 1)
+
+    calls = []
+    from PyQt6.QtWidgets import QMessageBox
+    monkeypatch.setattr(
+        QMessageBox, "warning", lambda *a, **k: calls.append(a)
+    )
+
+    torch_utils.maybe_warn_cpu_fallback(None)
+    torch_utils.maybe_warn_cpu_fallback(None)
+    assert len(calls) == 1
+
+
+def test_no_warning_dialog_when_device_ok(fake_torch, monkeypatch, qt_application):
+    fake_torch.is_available = lambda: True
+
+    calls = []
+    from PyQt6.QtWidgets import QMessageBox
+    monkeypatch.setattr(
+        QMessageBox, "warning", lambda *a, **k: calls.append(a)
+    )
+
+    torch_utils.maybe_warn_cpu_fallback(None)
+    assert calls == []


### PR DESCRIPTION
Hi @bnsreenu — this PR resolves two open issues. Each feature is its own commit, and the diff is scoped to just these two changes (plus tests and arc42 doc updates).

## Closes #27 — Filter image list by annotation status
Adds a combo box above the image list with **All images / Without annotations / With annotations**.

- Rows are hidden via `setRowHidden`, never removed — this keeps row-index iteration valid (DINO batch navigation, COCO import) and fires no spurious `currentRowChanged` → `switch_image`.
- A non-matching image is hidden even while selected; hiding doesn't touch `current_image`, so the canvas keeps showing the worked-on image while its row leaves the list.
- Multi-dim images count as annotated when any of their slices has annotations.
- Re-apply hooks into `ClassController.update_slice_list_colors`, which every annotation-mutation path already reaches.

(The arrow-key navigation half of #27 already works in current master.)

## Closes #57 — CPU fallback for unsupported CUDA compute capability
`torch.cuda.is_available()` returns True for Pascal GPUs (e.g. GTX 1050, sm_61) even though torch ≥ 2.8 wheels ship sm_70+ kernels only — so inference died with `CUDA error: no kernel image is available`.

- New `core/torch_utils.resolve_torch_device()` compares the device's compute capability against `torch.cuda.get_arch_list()` and falls back to CPU with an actionable warning (cached process-wide).
- Wired into SAM (`device=` on every predict), DINO (`_resolve_device`, `DINO_DEVICE` override preserved), and YOLO train/predict.
- One-time `QMessageBox` warning at SAM model pick / DINO detect, plus a README note with the torch-downgrade command for users who want to keep GPU inference.

## Testing
- 141 tests pass (26 new: filter unit tests, `torch_utils` unit tests with a fake torch module, and an end-to-end filter-wiring test through a full `ImageAnnotator`).
- Verified the device helper returns CPU + warning for a simulated sm_61 GPU and CUDA for supported cards.

Happy to adjust naming or split further if you'd prefer.