### PR TITLE
Five quick wins: #30 (YOLO save), #44 (UTF-8), #33 (nested edit), #60 (sort list), #56 (LZW TIFF)

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,14 @@ python -c "import torch; print(torch.cuda.is_available(), torch.cuda.get_device_
 
 You should see `True` and your GPU name. For other platforms or driver combinations, use the official selector at <https://pytorch.org/get-started/locally/>.
 
+#### Older NVIDIA GPUs (Pascal / Maxwell)
+
+PyTorch ≥ 2.8 wheels no longer include kernels for GPUs older than Volta (compute capability < 7.0), e.g. the GTX 10xx series (sm_61). On such cards the app detects the mismatch, warns once, and automatically runs inference on the CPU instead of crashing with `CUDA error: no kernel image is available`. To keep using the GPU, install an older PyTorch that still supports it:
+
+```bash
+pip install torch==2.4.1 torchvision==0.19.1 --index-url https://download.pytorch.org/whl/cu121
+```
+
 ## Usage
 
 1. Run the DigitalSreeni Image Annotator application:

--- a/docs/05_building_block_view.md
+++ b/docs/05_building_block_view.md
@@ -209,7 +209,7 @@ the controller graph.
 | Controller | Responsibility |
 |------------|----------------|
 | `ProjectController` | `.iap` save/load, auto-save, backup/restore, missing-image prompts, window-title sync. Owns the `is_loading_project` autosave guard (load/save round-trip safety, v0.8.12). |
-| `ImageController` | Open / load / switch images and slices. TIFF + CZI loaders, the multi-dim `DimensionDialog`, the `[-ndim:]` axis-slice bug fix from the v0.9.0 era. Image-list annotation-status filter (`image_has_annotations`, `apply_image_filter` — upstream #27). |
+| `ImageController` | Open / load / switch images and slices. TIFF + CZI loaders (with `imagecodecs` codec-error handling — #56), the multi-dim `DimensionDialog`, the `[-ndim:]` axis-slice bug fix from the v0.9.0 era. Image-list annotation-status filter (`image_has_annotations`, `apply_image_filter` — #27) and alphabetical sort (`sort_image_list` — #60). |
 | `AnnotationController` | Annotation CRUD, list sorting, highlight, edit-mode entry/exit, `finish_polygon`, `finish_rectangle`, `replace_annotations` (eraser path). Validates writes before mutating `all_annotations`. |
 | `ClassController` | Class add / delete / rename / colour / visibility. `update_slice_list_colors`, `is_class_visible`. |
 | `SAMController` | SAM box/points tool lifecycle, debounce timer, `_sam_inference_in_flight` re-entrancy guard (ADR-013), model picker. |

--- a/docs/05_building_block_view.md
+++ b/docs/05_building_block_view.md
@@ -33,7 +33,8 @@ src/digitalsreeni_image_annotator/
 	├── utils.py                       # Cross-cutting utilities
 	├── core/                          # Constants, annotation utils, image utils
 	│   ├── constants.py
-	│   └── annotation_utils.py
+	│   ├── annotation_utils.py
+	│   └── torch_utils.py             # Shared torch device resolution + CPU fallback (#57)
 	├── widgets/
 	│   ├── image_label.py             # ImageLabel - canvas widget; dispatcher
 	│   ├── canvas_context.py          # CanvasContext - narrow read view (ADR-018)
@@ -208,7 +209,7 @@ the controller graph.
 | Controller | Responsibility |
 |------------|----------------|
 | `ProjectController` | `.iap` save/load, auto-save, backup/restore, missing-image prompts, window-title sync. Owns the `is_loading_project` autosave guard (load/save round-trip safety, v0.8.12). |
-| `ImageController` | Open / load / switch images and slices. TIFF + CZI loaders, the multi-dim `DimensionDialog`, the `[-ndim:]` axis-slice bug fix from the v0.9.0 era. |
+| `ImageController` | Open / load / switch images and slices. TIFF + CZI loaders, the multi-dim `DimensionDialog`, the `[-ndim:]` axis-slice bug fix from the v0.9.0 era. Image-list annotation-status filter (`image_has_annotations`, `apply_image_filter` — upstream #27). |
 | `AnnotationController` | Annotation CRUD, list sorting, highlight, edit-mode entry/exit, `finish_polygon`, `finish_rectangle`, `replace_annotations` (eraser path). Validates writes before mutating `all_annotations`. |
 | `ClassController` | Class add / delete / rename / colour / visibility. `update_slice_list_colors`, `is_class_visible`. |
 | `SAMController` | SAM box/points tool lifecycle, debounce timer, `_sam_inference_in_flight` re-entrancy guard (ADR-013), model picker. |

--- a/docs/08_crosscutting_concepts.md
+++ b/docs/08_crosscutting_concepts.md
@@ -178,6 +178,33 @@ nothing visible" in v0.9.0 manual testing.
 | SAM 2 base | ~150MB | Medium-High | Slow | ⚠️ Use with caution |
 | SAM 2 large | ~400MB | High | Very Slow | ❌ Not recommended (crashes on limited resources) |
 
+### Device Selection & Compute-Capability Fallback
+
+`torch.cuda.is_available()` is **not** sufficient to decide on GPU
+inference: it returns True for any visible CUDA device even when the
+installed torch wheels contain no kernels for its compute capability
+(torch ≥ 2.8 wheels ship sm_70+ only, so a Pascal GTX 1050 / sm_61
+passes the check but every kernel launch fails with
+`CUDA error: no kernel image is available for execution on the device`
+— upstream issue #57).
+
+All inference paths therefore resolve their device through
+`core/torch_utils.resolve_torch_device()`:
+
+- compares `torch.cuda.get_device_capability(0)` against the minimum
+  `sm_*` in `torch.cuda.get_arch_list()`; on mismatch returns
+  `("cpu", warning)` instead of `"cuda"`,
+- caches the decision process-wide (SAM, DINO and YOLO share it),
+- prints the warning once; `maybe_warn_cpu_fallback(parent)` shows it
+  as a one-time `QMessageBox` from the SAM model picker and the DINO
+  detect entry points.
+
+SAM passes `device=` explicitly on every predict call; DINO's
+`_resolve_device()` delegates to the helper (the `DINO_DEVICE` env
+override still wins); the YOLO trainer passes `device=` to
+`model.train()` and prediction. Never call bare
+`torch.cuda.is_available()` to pick a device in new code.
+
 ## Dark Mode Support
 
 ### Stylesheet Switching
@@ -499,6 +526,37 @@ if image_path is None:
 The substring fallback is kept for backward compatibility with old
 projects that may have stored normalised image names (e.g. without
 extension); new code should prefer the exact-key path.
+
+## Image List Filter — Hide Rows, Never Remove Them
+
+The image list can be filtered by annotation status (combo above the
+list; upstream issue #27, `ImageController.apply_image_filter`). The
+filter uses `setRowHidden(i, True)` and must **never** remove items:
+
+- `DINOController._navigate_to_image_or_slice` and the COCO importer
+  iterate `image_list` rows by index; removing rows would shift
+  indices under them.
+- Removing the current item fires `currentRowChanged`, which is wired
+  to `switch_image` — a filter change could silently switch the
+  displayed image. Hiding fires nothing.
+
+A non-matching row is hidden **even when it is the current selection**.
+`setRowHidden` does not change `current_image` or fire
+`currentRowChanged`, so the canvas keeps showing the worked-on image
+while its row leaves the list — e.g. the current image gains its first
+annotation under the "Without annotations" filter and disappears from
+the list, but stays on screen until the user navigates away. Keyboard
+nav skips hidden rows. (Guaranteed by
+`test_hiding_current_row_keeps_canvas_and_fires_no_switch`.)
+
+Re-apply runs from `ClassController.update_slice_list_colors()`. The
+contract: every annotation-mutation site either calls that method
+directly **or** emits `annotationsBatchSaved` (whose handler
+`_on_annotations_batch_saved` calls it). All `annotationCommitted`
+emitters follow up with `annotationsBatchSaved`
+(image_label.py / paint_tool.py), so both commit paths are covered.
+New mutation paths must keep one of those two routes — don't add
+bespoke `apply_image_filter()` call sites.
 
 ## Canvas Decoupling — Signals + CanvasContext
 

--- a/docs/08_crosscutting_concepts.md
+++ b/docs/08_crosscutting_concepts.md
@@ -558,6 +558,37 @@ emitters follow up with `annotationsBatchSaved`
 New mutation paths must keep one of those two routes — don't add
 bespoke `apply_image_filter()` call sites.
 
+## Image List Sorting — Rebuild, Don't `setSortingEnabled`
+
+The image list is kept alphabetical (upstream issue #60,
+`ImageController.sort_image_list`). Two constraints shape the
+implementation:
+
+- `currentRowChanged` is wired to `switch_image`, so `setSortingEnabled(True)`
+  is forbidden — a live re-sort would reorder rows and fire spurious
+  image switches.
+- COCO import (and other positional lookups) assume `all_images[i]`
+  matches `image_list.item(i)`. So the model and the view are sorted
+  **together**: `all_images` is sorted, then the list is cleared and
+  repopulated from it with `blockSignals(True)` around the rebuild, and
+  the prior (or newly added) selection is restored explicitly. The #27
+  filter is re-applied at the end of the rebuild.
+
+`update_image_list` routes through `sort_image_list`; `add_images_to_list`
+calls it with the first added file selected. It is skipped per-image
+during project load (the list is rebuilt once via `update_ui`) to avoid
+an O(n²) re-sort.
+
+## TIFF Compression Codecs
+
+Reading an LZW- (or otherwise) compressed TIFF requires the optional
+`imagecodecs` package; without it `tifffile` raises `ValueError` mid-read
+(upstream issue #56). `imagecodecs` is now a hard dependency, but
+`ImageController.add_images_to_list` also catches the codec `ValueError`
+(`_is_missing_codec_error`) and shows an actionable "pip install
+imagecodecs" dialog, skipping the file instead of crashing or leaving a
+half-added entry. Non-codec `ValueError`s still propagate.
+
 ## Canvas Decoupling — Signals + CanvasContext
 
 `ImageLabel` (the canvas widget) does **not** hold a reference to

--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ setup(
         "numpy>=2.0.0",  # pip resolves 2.4+ on Py3.14, 2.2.x on Py3.10 (last 3.10-compatible)
         "Pillow>=10.0.0",
         "tifffile>=2023.0.0",
+        "imagecodecs>=2023.1.23",  # tifffile needs it for LZW/compressed TIFF (#56)
         "czifile>=2019.7.2",
         "opencv-python>=4.8.0",
         "pyyaml>=6.0.0",

--- a/src/digitalsreeni_image_annotator/annotator_window.py
+++ b/src/digitalsreeni_image_annotator/annotator_window.py
@@ -273,6 +273,9 @@ class ImageAnnotator(QMainWindow):
     def update_image_list(self):
         return self.image_controller.update_image_list()
 
+    def apply_image_filter(self):
+        return self.image_controller.apply_image_filter()
+
     def select_class(self, index):
         return self.class_controller.select_class(index)
 

--- a/src/digitalsreeni_image_annotator/controllers/annotation_controller.py
+++ b/src/digitalsreeni_image_annotator/controllers/annotation_controller.py
@@ -217,7 +217,7 @@ class AnnotationController(QObject):
         if not file_name:
             return
 
-        with open(file_name, "r") as f:
+        with open(file_name, "r", encoding='utf-8') as f:
             self.mw.loaded_json = json.load(f)
 
         self.mw.class_list.clear()
@@ -259,9 +259,11 @@ class AnnotationController(QObject):
 
         for img in json_images.values():
             updated_all_images.append(img)
-            self.mw.image_list.addItem(img["file_name"])
 
         self.mw.all_images = updated_all_images
+        # Rebuild the list in sorted order (issue #60). The reconciliation
+        # loop above already consumed the pre-sort row/index alignment.
+        self.mw.update_image_list()
 
         self.mw.all_annotations.clear()
         for annotation in self.mw.loaded_json["annotations"]:
@@ -538,7 +540,7 @@ class AnnotationController(QObject):
         msg_box.setText("Do you want to keep the original annotations?")
         msg_box.setIcon(QMessageBox.Icon.Question)
 
-        keep_button = msg_box.addButton("Keep", QMessageBox.ButtonRole.YesRole)
+        msg_box.addButton("Keep", QMessageBox.ButtonRole.YesRole)
         delete_button = msg_box.addButton("Delete", QMessageBox.ButtonRole.NoRole)
         cancel_button = msg_box.addButton("Cancel", QMessageBox.ButtonRole.RejectRole)
 

--- a/src/digitalsreeni_image_annotator/controllers/class_controller.py
+++ b/src/digitalsreeni_image_annotator/controllers/class_controller.py
@@ -96,6 +96,13 @@ class ClassController(QObject):
 
         self.mw.slice_list.repaint()
 
+        # Re-apply hook for the image-list annotation filter. Contract:
+        # every annotation-mutation site either calls this method directly
+        # or emits annotationsBatchSaved, whose handler
+        # (_on_annotations_batch_saved) calls it. New mutation paths must
+        # keep one of those two routes.
+        self.mw.image_controller.apply_image_filter()
+
     def add_class(self, class_name=None, color=None):
         if not self.mw.image_label.check_unsaved_changes():
             return

--- a/src/digitalsreeni_image_annotator/controllers/dino_controller.py
+++ b/src/digitalsreeni_image_annotator/controllers/dino_controller.py
@@ -211,6 +211,9 @@ class DINOController(QObject):
                                 "Please add at least one class with phrases.")
             return
 
+        from ..core.torch_utils import maybe_warn_cpu_fallback
+        maybe_warn_cpu_fallback(self.mw)
+
         self.mw.btn_detect_single.setEnabled(False)
         self.mw.btn_detect_batch.setEnabled(False)
 
@@ -359,6 +362,9 @@ class DINOController(QObject):
             QMessageBox.warning(self.mw, "No Classes",
                                 "Please add at least one class with phrases.")
             return
+
+        from ..core.torch_utils import maybe_warn_cpu_fallback
+        maybe_warn_cpu_fallback(self.mw)
 
         # Prevent stale temp annotations from a prior single-image review from
         # confusing the batch results handler or the DINOReviewEventFilter.

--- a/src/digitalsreeni_image_annotator/controllers/image_controller.py
+++ b/src/digitalsreeni_image_annotator/controllers/image_controller.py
@@ -89,6 +89,73 @@ class ImageController(QObject):
         self.mw.image_list.clear()
         for image_info in self.mw.all_images:
             self.mw.image_list.addItem(image_info["file_name"])
+        self.apply_image_filter()
+
+    def image_has_annotations(self, image_info):
+        """True if the image (or, for multi-dim images, any of its slices)
+        has at least one annotation."""
+
+        def _non_empty(by_class):
+            return bool(by_class) and any(by_class.values())
+
+        file_name = image_info["file_name"]
+        if _non_empty(self.mw.all_annotations.get(file_name, {})):
+            return True
+
+        if image_info.get("is_multi_slice", False):
+            base_name = os.path.splitext(file_name)[0]
+            slices = self.mw.image_slices.get(base_name)
+            if slices:
+                return any(
+                    _non_empty(self.mw.all_annotations.get(slice_name, {}))
+                    for slice_name, _ in slices
+                )
+            # Slices not extracted yet (e.g. load cancelled) — slice keys
+            # are f"{base_name}_T1_Z5_..." so a "{base_name}_" prefix match
+            # is exact enough; a bare substring match would not be. Caveat:
+            # this also matches "{base_name}_8bit" artifact keys, which
+            # redefine_dimensions deliberately excludes — acceptable here
+            # since an _8bit key with annotations still means "this image
+            # has annotations".
+            prefix = base_name + "_"
+            return any(
+                key.startswith(prefix) and _non_empty(by_class)
+                for key, by_class in self.mw.all_annotations.items()
+            )
+
+        return False
+
+    def apply_image_filter(self):
+        """Hide image-list rows that don't match the annotation-status
+        filter (upstream issue #27).
+
+        Rows are hidden via setRowHidden, never removed: other code
+        (DINO batch navigation, COCO import) iterates the list by row
+        index, and hiding fires no currentRowChanged so it cannot
+        trigger a spurious switch_image.
+
+        A non-matching row is hidden even when it is the current
+        selection — hiding does not change `current_image`, so the canvas
+        keeps showing the worked-on image while its row leaves the list
+        (e.g. the image just gained its first annotation under the
+        "Without annotations" filter). Keyboard nav skips hidden rows.
+        """
+        combo = getattr(self.mw, "image_filter_combo", None)
+        if combo is None:
+            return
+        mode = combo.currentIndex()  # 0 = all, 1 = without, 2 = with
+        if mode == 0:
+            # Default case runs on every update_slice_list_colors —
+            # keep it a plain unhide pass with no annotation scans.
+            for i in range(self.mw.image_list.count()):
+                self.mw.image_list.setRowHidden(i, False)
+            return
+        infos = {info["file_name"]: info for info in self.mw.all_images}
+        for i in range(self.mw.image_list.count()):
+            info = infos.get(self.mw.image_list.item(i).text())
+            annotated = bool(info) and self.image_has_annotations(info)
+            hide = annotated if mode == 1 else not annotated
+            self.mw.image_list.setRowHidden(i, hide)
 
     def setup_slice_list(self):
         self.mw.slice_list = QListWidget()
@@ -161,6 +228,8 @@ class ImageController(QObject):
         if first_added_item:
             self.mw.image_list.setCurrentItem(first_added_item)
             self.switch_image(first_added_item)
+
+        self.apply_image_filter()
 
         if not self.mw.is_loading_project:
             self.mw.auto_save()

--- a/src/digitalsreeni_image_annotator/controllers/image_controller.py
+++ b/src/digitalsreeni_image_annotator/controllers/image_controller.py
@@ -86,10 +86,55 @@ class ImageController(QObject):
         self.mw = main_window
 
     def update_image_list(self):
+        # Rebuild (and sort) the list, preserving the current selection
+        # without switching images.
+        self.sort_image_list()
+
+    def sort_image_list(self, select_name=None, do_switch=False):
+        """Populate image_list in alphabetical order (upstream issue #60).
+
+        Sorts the model (`all_images`) and the view together so the
+        `all_images[i]` ↔ `image_list.item(i)` positional invariant holds
+        (relied on by COCO import reconciliation). `setSortingEnabled` is
+        deliberately NOT used: `currentRowChanged` is wired to
+        `switch_image`, so a live re-sort would fire spurious image
+        switches. We rebuild with signals blocked instead, then re-select
+        explicitly.
+
+        select_name: file to select after the rebuild (defaults to the
+        previously-current item). do_switch: call switch_image once for
+        the selected item (used when adding new images).
+        """
+        current = None
+        if self.mw.image_list.currentItem() is not None:
+            current = self.mw.image_list.currentItem().text()
+
+        self.mw.all_images.sort(
+            key=lambda info: (
+                info.get("file_name", "").casefold(),
+                info.get("file_name", ""),
+            )
+        )
+
+        self.mw.image_list.blockSignals(True)
         self.mw.image_list.clear()
-        for image_info in self.mw.all_images:
-            self.mw.image_list.addItem(image_info["file_name"])
+        for info in self.mw.all_images:
+            self.mw.image_list.addItem(info["file_name"])
+        self.mw.image_list.blockSignals(False)
+
         self.apply_image_filter()
+
+        target = select_name if select_name is not None else current
+        if target is not None:
+            items = self.mw.image_list.findItems(
+                target, Qt.MatchFlag.MatchExactly
+            )
+            if items:
+                self.mw.image_list.blockSignals(True)
+                self.mw.image_list.setCurrentItem(items[0])
+                self.mw.image_list.blockSignals(False)
+                if do_switch:
+                    self.switch_image(items[0])
 
     def image_has_annotations(self, image_info):
         """True if the image (or, for multi-dim images, any of its slices)
@@ -181,7 +226,7 @@ class ImageController(QObject):
             self.add_images_to_list(file_names)
 
     def add_images_to_list(self, file_names):
-        first_added_item = None
+        first_added_name = None
         for file_name in file_names:
             base_name = os.path.basename(file_name)
             if base_name not in self.mw.image_paths:
@@ -194,7 +239,25 @@ class ImageController(QObject):
                 }
 
                 if file_name.lower().endswith((".tif", ".tiff", ".czi")):
-                    self.load_multi_slice_image(file_name)
+                    try:
+                        self.load_multi_slice_image(file_name)
+                    except ValueError as e:
+                        # LZW/compressed TIFFs need the optional imagecodecs
+                        # package; without it tifffile raises ValueError and
+                        # the app used to crash (#56). Skip the file with an
+                        # actionable message instead of a half-added entry.
+                        if self._is_missing_codec_error(e):
+                            QMessageBox.critical(
+                                self.mw,
+                                "Cannot open TIFF",
+                                f"'{base_name}' uses a compression that requires "
+                                "the 'imagecodecs' package, which is not "
+                                "installed.\n\nInstall it with:\n"
+                                "    pip install imagecodecs\n\n"
+                                "then reopen the image.",
+                            )
+                            continue
+                        raise
                     base_name_without_ext = os.path.splitext(base_name)[0]
                     if (
                         base_name_without_ext in self.mw.image_slices
@@ -218,21 +281,33 @@ class ImageController(QObject):
                     image_info["width"] = image.width()
 
                 self.mw.all_images.append(image_info)
-                item = QListWidgetItem(base_name)
-                self.mw.image_list.addItem(item)
-                if first_added_item is None:
-                    first_added_item = item
+                if first_added_name is None:
+                    first_added_name = base_name
 
                 self.mw.image_paths[base_name] = file_name
 
-        if first_added_item:
-            self.mw.image_list.setCurrentItem(first_added_item)
-            self.switch_image(first_added_item)
-
-        self.apply_image_filter()
+        # Rebuild the list in sorted order and select/switch to the first
+        # newly added image. Skipped during project load (the list is
+        # rebuilt once via update_ui afterwards, and load picks row 0) to
+        # avoid an O(n^2) re-sort per image.
+        if first_added_name is not None and not self.mw.is_loading_project:
+            self.sort_image_list(select_name=first_added_name, do_switch=True)
+        else:
+            self.apply_image_filter()
 
         if not self.mw.is_loading_project:
             self.mw.auto_save()
+
+    @staticmethod
+    def _is_missing_codec_error(exc):
+        """True if a tifffile read failed because the imagecodecs package
+        is unavailable for the TIFF's compression — e.g. LZW (#56).
+
+        Matches only the reliable 'imagecodecs' token: tifffile names the
+        package in every such message. A broader 'compression' match would
+        silently swallow unrelated ValueErrors behind a misleading dialog.
+        """
+        return "imagecodecs" in str(exc).lower()
 
     def update_all_images(self, new_image_info):
         for info in new_image_info:

--- a/src/digitalsreeni_image_annotator/controllers/project_controller.py
+++ b/src/digitalsreeni_image_annotator/controllers/project_controller.py
@@ -116,7 +116,7 @@ class ProjectController(QObject):
             try:
                 self.mw.is_loading_project = True
 
-                with open(project_file, "r") as f:
+                with open(project_file, "r", encoding='utf-8') as f:
                     project_data = json.load(f)
 
                 self.mw.clear_all(show_messages=False)
@@ -490,7 +490,7 @@ class ProjectController(QObject):
         if dino_cfg["phrases"] or dino_cfg["thresholds"]:
             project_data["dino_config"] = dino_cfg
 
-        with open(self.mw.current_project_file, "w") as f:
+        with open(self.mw.current_project_file, "w", encoding='utf-8') as f:
             json.dump(image_utils.convert_to_serializable(project_data), f, indent=2)
 
         if show_message:

--- a/src/digitalsreeni_image_annotator/controllers/sam_controller.py
+++ b/src/digitalsreeni_image_annotator/controllers/sam_controller.py
@@ -214,6 +214,10 @@ class SAMController(QObject):
 
         if model_name != "Pick a SAM Model":
             print(f"Changed SAM model to: {model_name}")
+            # One-time dialog if CUDA exists but the torch wheels can't
+            # run it (e.g. Pascal sm_61 on torch>=2.8) — upstream #57.
+            from ..core.torch_utils import maybe_warn_cpu_fallback
+            maybe_warn_cpu_fallback(self.mw)
         else:
             self.deactivate_sam_tools()
             print("SAM model unset")

--- a/src/digitalsreeni_image_annotator/core/torch_utils.py
+++ b/src/digitalsreeni_image_annotator/core/torch_utils.py
@@ -1,0 +1,95 @@
+"""
+Shared torch device selection (upstream issue #57).
+
+torch.cuda.is_available() returns True for any visible CUDA device, even
+when the installed torch wheels contain no kernels for its compute
+capability (e.g. torch >= 2.8 wheels ship sm_70+ only, so a Pascal
+GTX 1050 / sm_61 passes the availability check but every kernel launch
+dies with "CUDA error: no kernel image is available for execution on
+the device"). This module detects that mismatch up front and falls back
+to CPU with an actionable warning instead of a cryptic crash mid-inference.
+"""
+
+_cached_result = None
+
+
+def resolve_torch_device():
+    """Return ``(device, warning)``.
+
+    ``device`` is ``"cuda"`` or ``"cpu"``; ``warning`` is None or a
+    human-readable explanation of why CUDA was rejected (printed once on
+    first call). The result is cached for the process lifetime so SAM,
+    DINO and YOLO all share one decision.
+    """
+    global _cached_result
+    if _cached_result is None:
+        _cached_result = _resolve()
+        if _cached_result[1]:
+            print(f"[torch] {_cached_result[1]}")
+    return _cached_result
+
+
+def _resolve():
+    try:
+        import torch
+    except Exception:
+        return ("cpu", None)
+
+    try:
+        if not torch.cuda.is_available():
+            return ("cpu", None)
+
+        # Deliberately device-0-only: on a mixed multi-GPU box this may
+        # force CPU even though a later index is supported; the app never
+        # selects a non-default CUDA device anywhere, so index 0 is what
+        # inference would actually run on.
+        major, minor = torch.cuda.get_device_capability(0)
+        device_sm = major * 10 + minor
+        compiled_sms = _parse_arch_list(torch.cuda.get_arch_list())
+
+        if compiled_sms and device_sm < min(compiled_sms):
+            gpu = torch.cuda.get_device_name(0)
+            return (
+                "cpu",
+                f"GPU '{gpu}' (compute capability sm_{device_sm}) is not "
+                f"supported by the installed PyTorch build (compiled for "
+                f"sm_{min(compiled_sms)}+). Falling back to CPU. For GPU "
+                f"inference install an older PyTorch with support for this "
+                f"card, e.g.:\n"
+                f"  pip install torch==2.4.1 torchvision==0.19.1 "
+                f"--index-url https://download.pytorch.org/whl/cu121",
+            )
+        return ("cuda", None)
+    except Exception as e:
+        # Any probing failure: prefer a working CPU path over a crash.
+        return ("cpu", f"Could not verify CUDA compatibility ({e}); "
+                       f"falling back to CPU.")
+
+
+_warning_shown = False
+
+
+def maybe_warn_cpu_fallback(parent=None):
+    """Show the CUDA-incompatibility warning as a dialog, once per session.
+
+    No-op when the device resolved cleanly (CUDA usable, or no GPU at
+    all — running on CPU without a discrete GPU is expected and needs
+    no dialog).
+    """
+    global _warning_shown
+    _, warning = resolve_torch_device()
+    if warning is None or _warning_shown:
+        return
+    _warning_shown = True
+    from PyQt6.QtWidgets import QMessageBox
+    QMessageBox.warning(parent, "GPU not usable — running on CPU", warning)
+
+
+def _parse_arch_list(arch_list):
+    """Extract numeric sm values from e.g. ["sm_70", "sm_80", "compute_90"]."""
+    sms = []
+    for arch in arch_list:
+        prefix, _, num = arch.rpartition("_")
+        if prefix.endswith("sm") and num.isdigit():
+            sms.append(int(num))
+    return sms

--- a/src/digitalsreeni_image_annotator/dialogs/coco_json_combiner.py
+++ b/src/digitalsreeni_image_annotator/dialogs/coco_json_combiner.py
@@ -63,7 +63,7 @@ class COCOJSONCombinerDialog(QDialog):
     
         try:
             for file_path in self.json_files:
-                with open(file_path, 'r') as f:
+                with open(file_path, 'r', encoding='utf-8') as f:
                     data = json.load(f)
                 
                 # Combine categories
@@ -98,7 +98,7 @@ class COCOJSONCombinerDialog(QDialog):
     
             output_file, _ = QFileDialog.getSaveFileName(self, "Save Combined JSON", "", "JSON Files (*.json)")
             if output_file:
-                with open(output_file, 'w') as f:
+                with open(output_file, 'w', encoding='utf-8') as f:
                     json.dump(combined_data, f, indent=2)
                 QMessageBox.information(self, "Success", f"Combined JSON saved to {output_file}")
     

--- a/src/digitalsreeni_image_annotator/dialogs/dataset_splitter.py
+++ b/src/digitalsreeni_image_annotator/dialogs/dataset_splitter.py
@@ -160,7 +160,7 @@ class DatasetSplitterTool(QDialog):
         QMessageBox.information(self, "Success", "Dataset split successfully!")
 
     def split_images_and_annotations(self):
-        with open(self.json_file, 'r') as f:
+        with open(self.json_file, 'r', encoding='utf-8') as f:
             coco_data = json.load(f)
 
         image_files = [img['file_name'] for img in coco_data['images']]
@@ -246,7 +246,7 @@ class DatasetSplitterTool(QDialog):
         subset_dir = os.path.join(self.output_directory, subset)
         os.makedirs(subset_dir, exist_ok=True)
         output_file = os.path.join(subset_dir, f"{subset}_annotations.json")
-        with open(output_file, 'w') as f:
+        with open(output_file, 'w', encoding='utf-8') as f:
             json.dump(data, f, indent=2)
 
     def split_yolo_format(self, coco_data, train_images, val_images, test_images):
@@ -289,7 +289,7 @@ class DatasetSplitterTool(QDialog):
                 
                 # Create YOLO format labels
                 label_file = os.path.join(labels_dir, os.path.splitext(image_file)[0] + ".txt")
-                with open(label_file, "w") as f:
+                with open(label_file, "w", encoding='utf-8') as f:
                     for ann in annotations:
                         # Convert COCO class id to YOLO class id
                         yolo_class = categories[ann["category_id"]]
@@ -310,7 +310,7 @@ class DatasetSplitterTool(QDialog):
         }
         yaml_data.update(yaml_paths)  # Add only paths for non-empty splits
 
-        with open(os.path.join(self.output_directory, 'data.yaml'), 'w') as f:
+        with open(os.path.join(self.output_directory, 'data.yaml'), 'w', encoding='utf-8') as f:
             yaml.dump(yaml_data, f, default_flow_style=False)
 
         QMessageBox.information(self, "Success", "Dataset and YOLO annotations split successfully!")

--- a/src/digitalsreeni_image_annotator/dialogs/dicom_converter.py
+++ b/src/digitalsreeni_image_annotator/dialogs/dicom_converter.py
@@ -3,8 +3,7 @@ import json
 import numpy as np
 from datetime import datetime
 from PyQt6.QtWidgets import (QDialog, QVBoxLayout, QHBoxLayout, QPushButton, QFileDialog, 
-                            QLabel, QProgressDialog, QRadioButton, QButtonGroup, 
-                            QMessageBox, QApplication, QGroupBox)
+                            QLabel, QProgressDialog, QRadioButton, QMessageBox, QApplication, QGroupBox)
 from PyQt6.QtCore import Qt
 import pydicom
 from pydicom.pixel_data_handlers.util import apply_voi_lut
@@ -230,7 +229,7 @@ class DicomConverter(QDialog):
             metadata_file = os.path.join(self.output_directory, 
                                        os.path.splitext(os.path.basename(self.input_file))[0] + 
                                        "_metadata.json")
-            with open(metadata_file, 'w') as f:
+            with open(metadata_file, 'w', encoding='utf-8') as f:
                 json.dump(series_metadata, f, indent=2)
             
             # Get physical sizes from metadata

--- a/src/digitalsreeni_image_annotator/dialogs/dino_merge_dialog.py
+++ b/src/digitalsreeni_image_annotator/dialogs/dino_merge_dialog.py
@@ -6,7 +6,6 @@ Ported from annotation_tool_v4.py _MergeCOCODialog.
 
 import json
 import math
-import os
 import random
 import traceback
 from collections import defaultdict
@@ -180,7 +179,7 @@ class DinoMergeDialog(QDialog):
             # Load and validate
             records = []
             for path in coco_files:
-                with open(path) as f:
+                with open(path, encoding='utf-8') as f:
                     data = json.load(f)
                 if not data.get("images") or not data.get("annotations"):
                     self._log_msg(f"  [skip] {path.name}: empty.")
@@ -295,9 +294,9 @@ class DinoMergeDialog(QDialog):
             train_data = _build_coco(train_imgs)
             val_data = _build_coco(val_imgs)
 
-            with open(out_path / "train.json", "w") as f:
+            with open(out_path / "train.json", "w", encoding='utf-8') as f:
                 json.dump(train_data, f, indent=2)
-            with open(out_path / "val.json", "w") as f:
+            with open(out_path / "val.json", "w", encoding='utf-8') as f:
                 json.dump(val_data, f, indent=2)
 
             self._log_msg(f"Train images: {len(train_imgs)}, annotations: {len(train_data['annotations'])}")

--- a/src/digitalsreeni_image_annotator/dialogs/image_augmenter.py
+++ b/src/digitalsreeni_image_annotator/dialogs/image_augmenter.py
@@ -169,7 +169,7 @@ class ImageAugmenterDialog(QDialog):
         self.coco_file, _ = QFileDialog.getOpenFileName(self, "Select COCO JSON File", "", "JSON Files (*.json)")
         if self.coco_file:
             self.coco_label.setText(f"COCO JSON File: {os.path.basename(self.coco_file)}")
-            with open(self.coco_file, 'r') as f:
+            with open(self.coco_file, 'r', encoding='utf-8') as f:
                 self.coco_data = json.load(f)
             self.coco_check.setChecked(True)  # Automatically check the box when a file is loaded
                 
@@ -270,7 +270,7 @@ class ImageAugmenterDialog(QDialog):
     
         if self.coco_check.isChecked():
             output_coco_path = os.path.join(self.output_dir, "augmented_annotations.json")
-            with open(output_coco_path, 'w') as f:
+            with open(output_coco_path, 'w', encoding='utf-8') as f:
                 json.dump(augmented_coco_data, f, indent=2)
     
         QMessageBox.information(self, "Augmentation Complete", "Image and annotation augmentation has been completed successfully.")

--- a/src/digitalsreeni_image_annotator/dialogs/project_search.py
+++ b/src/digitalsreeni_image_annotator/dialogs/project_search.py
@@ -1,7 +1,7 @@
 from PyQt6.QtWidgets import (QDialog, QVBoxLayout, QHBoxLayout, QLineEdit, QPushButton, 
-                             QDateEdit, QLabel, QListWidget, QDialogButtonBox, QFormLayout,
+                             QDateEdit, QListWidget, QDialogButtonBox, QFormLayout,
                              QFileDialog, QMessageBox)
-from PyQt6.QtCore import Qt, QDate
+from PyQt6.QtCore import QDate
 import os
 import json
 from datetime import datetime
@@ -83,7 +83,7 @@ class ProjectSearchDialog(QDialog):
                 if filename.endswith('.iap'):
                     project_path = os.path.join(root, filename)
                     try:
-                        with open(project_path, 'r') as f:
+                        with open(project_path, 'r', encoding='utf-8') as f:
                             project_data = json.load(f)
                         
                         if self.project_matches(project_data, query, start_date, end_date):

--- a/src/digitalsreeni_image_annotator/dialogs/yolo_trainer.py
+++ b/src/digitalsreeni_image_annotator/dialogs/yolo_trainer.py
@@ -1,7 +1,7 @@
 import os
 from PyQt6.QtWidgets import QFileDialog, QMessageBox
 from PyQt6.QtWidgets import (QDialog, QVBoxLayout, QHBoxLayout, QPushButton,
-                             QLineEdit, QLabel, QFileDialog, QDialogButtonBox)
+                             QLineEdit, QLabel, QDialogButtonBox)
 import yaml
 import numpy as np
 from pathlib import Path
@@ -11,8 +11,8 @@ from ..io.export_formats import export_yolo_v5plus
 from collections import deque
 
 
-from PyQt6.QtWidgets import QDialog, QVBoxLayout, QTextEdit, QPushButton
-from PyQt6.QtCore import Qt, pyqtSignal, QObject
+from PyQt6.QtWidgets import QTextEdit
+from PyQt6.QtCore import pyqtSignal, QObject
 
 class TrainingInfoDialog(QDialog):
     stop_signal = pyqtSignal()
@@ -140,7 +140,7 @@ class YOLOTrainer(QObject):
         )
         
         yaml_path = Path(yaml_path)
-        with yaml_path.open('r') as f:
+        with yaml_path.open('r', encoding='utf-8') as f:
             yaml_content = yaml.safe_load(f)
         
         # Update paths for new YOLO v5+ structure
@@ -148,7 +148,7 @@ class YOLOTrainer(QObject):
         yaml_content['val'] = 'images/val'      # Changed from train/images
         yaml_content['test'] = '../test/images'
         
-        with yaml_path.open('w') as f:
+        with yaml_path.open('w', encoding='utf-8') as f:
             yaml.dump(yaml_content, f, default_flow_style=False)
         
         self.yaml_path = str(yaml_path)
@@ -158,7 +158,7 @@ class YOLOTrainer(QObject):
         if yaml_path is None:
             yaml_path, _ = QFileDialog.getOpenFileName(self.main_window, "Select YOLO Dataset YAML", "", "YAML Files (*.yaml *.yml)")
         if yaml_path and os.path.exists(yaml_path):
-            with open(yaml_path, 'r') as f:
+            with open(yaml_path, 'r', encoding='utf-8') as f:
                 try:
                     yaml_data = yaml.safe_load(f)
                     print(f"Loaded YAML contents: {yaml_data}")
@@ -175,7 +175,7 @@ class YOLOTrainer(QObject):
                     self.yaml_path = yaml_path
     
                     # Write the updated YAML back to the file
-                    with open(yaml_path, 'w') as f:
+                    with open(yaml_path, 'w', encoding='utf-8') as f:
                         yaml.dump(yaml_data, f, default_flow_style=False)
     
                     return True
@@ -218,7 +218,7 @@ class YOLOTrainer(QObject):
             print(f"Training with YAML: {yaml_path}")
             print(f"YAML directory: {yaml_dir}")
             
-            with yaml_path.open('r') as f:
+            with yaml_path.open('r', encoding='utf-8') as f:
                 yaml_content = yaml.safe_load(f)
             print(f"YAML content: {yaml_content}")
             
@@ -237,7 +237,7 @@ class YOLOTrainer(QObject):
             
             # Write updated YAML with adjusted paths
             temp_yaml_path = yaml_dir / 'temp_train.yaml'
-            with temp_yaml_path.open('w') as f:
+            with temp_yaml_path.open('w', encoding='utf-8') as f:
                 yaml.dump(yaml_content, f, default_flow_style=False)
             
             print(f"Training with updated YAML: {temp_yaml_path}")
@@ -258,7 +258,7 @@ class YOLOTrainer(QObject):
         yaml_path = Path(self.yaml_path)
         yaml_dir = yaml_path.parent
         
-        with yaml_path.open('r') as f:
+        with yaml_path.open('r', encoding='utf-8') as f:
             yaml_content = yaml.safe_load(f)
         
         # Use paths from YAML content
@@ -279,9 +279,9 @@ class YOLOTrainer(QObject):
             missing_dirs.append(f"Validation labels directory: {val_labels_dir}")
         
         if missing_dirs:
-            raise FileNotFoundError(f"The following directories were not found:\n" + "\n".join(missing_dirs))
+            raise FileNotFoundError("The following directories were not found:\n" + "\n".join(missing_dirs))
         
-        print(f"Dataset structure verified:")
+        print("Dataset structure verified:")
         print(f"Train images: {train_images_dir}")
         print(f"Train labels: {train_labels_dir}")
         print(f"Val images: {val_images_dir}")
@@ -290,7 +290,7 @@ class YOLOTrainer(QObject):
     def check_ultralytics_settings(self):
         settings_path = Path.home() / ".config" / "Ultralytics" / "settings.yaml"
         if settings_path.exists():
-            with settings_path.open('r') as f:
+            with settings_path.open('r', encoding='utf-8') as f:
                 settings = yaml.safe_load(f)
             print(f"Ultralytics settings: {settings}")
         else:
@@ -332,7 +332,7 @@ class YOLOTrainer(QObject):
         info = f"Epoch {epoch}/{total_epochs}, Loss: {loss:.4f}"
         self.epoch_info.append(info)
         
-        display_text = f"Current Progress:\n" + "\n".join(self.epoch_info)
+        display_text = "Current Progress:\n" + "\n".join(self.epoch_info)
         if self.progress_callback:
             self.progress_callback(display_text)
 
@@ -342,7 +342,7 @@ class YOLOTrainer(QObject):
             raise ValueError("No model to save. Please train a model first.")
         save_path, _ = QFileDialog.getSaveFileName(self.main_window, "Save YOLO Model", "", "YOLO Model (*.pt)")
         if save_path:
-            self.model.export(save_path)
+            self.model.save(save_path)
             return True
         return False
 
@@ -351,7 +351,7 @@ class YOLOTrainer(QObject):
 
         try:
             self.model = YOLO(model_path)
-            with open(yaml_path, 'r') as f:
+            with open(yaml_path, 'r', encoding='utf-8') as f:
                 self.prediction_yaml = yaml.safe_load(f)
             
             if 'names' not in self.prediction_yaml:

--- a/src/digitalsreeni_image_annotator/dialogs/yolo_trainer.py
+++ b/src/digitalsreeni_image_annotator/dialogs/yolo_trainer.py
@@ -243,7 +243,9 @@ class YOLOTrainer(QObject):
             print(f"Training with updated YAML: {temp_yaml_path}")
             print(f"Updated YAML content: {yaml_content}")
             
-            results = self.model.train(data=str(temp_yaml_path), epochs=epochs, imgsz=imgsz)
+            from ..core.torch_utils import resolve_torch_device
+            device, _ = resolve_torch_device()
+            results = self.model.train(data=str(temp_yaml_path), epochs=epochs, imgsz=imgsz, device=device)
             return results
         finally:
             # Clear the callback
@@ -375,12 +377,10 @@ class YOLOTrainer(QObject):
     def predict(self, input_data):
         if self.model is None:
             raise ValueError("No model loaded. Please load a model first.")
-        if isinstance(input_data, str):
-            # It's a file path
-            results = self.model(input_data, task='segment', conf=self.conf_threshold, save=False, show=False)
-        elif isinstance(input_data, np.ndarray):
-            # It's a numpy array
-            results = self.model(input_data, task='segment', conf=self.conf_threshold, save=False, show=False)
+        from ..core.torch_utils import resolve_torch_device
+        device, _ = resolve_torch_device()
+        if isinstance(input_data, (str, np.ndarray)):
+            results = self.model(input_data, task='segment', conf=self.conf_threshold, save=False, show=False, device=device)
         else:
             raise ValueError("Invalid input type. Expected file path or numpy array.")
         

--- a/src/digitalsreeni_image_annotator/inference/dino_utils.py
+++ b/src/digitalsreeni_image_annotator/inference/dino_utils.py
@@ -73,15 +73,15 @@ class DINOUtils(QObject):
     # ── model lifecycle ───────────────────────────────────────────────
 
     def _resolve_device(self) -> str:
-        """Pick CUDA if available; honour DINO_DEVICE env override."""
+        """Pick CUDA if available and usable; honour DINO_DEVICE override."""
         env = os.environ.get("DINO_DEVICE")
         if env:
             return env
-        try:
-            import torch
-            return "cuda" if torch.cuda.is_available() else "cpu"
-        except Exception:
-            return "cpu"
+        # Shared helper also rejects GPUs whose compute capability the
+        # installed torch wheels can't run (upstream issue #57).
+        from ..core.torch_utils import resolve_torch_device
+        device, _ = resolve_torch_device()
+        return device
 
     def _load_model_blocking(self, model_path: str) -> None:
         """Load (cache) the Grounding DINO model for ``model_path``."""

--- a/src/digitalsreeni_image_annotator/inference/sam_utils.py
+++ b/src/digitalsreeni_image_annotator/inference/sam_utils.py
@@ -302,6 +302,7 @@ class SAMUtils(QObject):
         self.current_sam_model: str | None = None
         self._model = None  # ultralytics.SAM instance once loaded
         self._loaded_model_file: str | None = None
+        self._device: str | None = None  # resolved at model load
 
     # ── model lifecycle ────────────────────────────────────────────────
 
@@ -329,21 +330,23 @@ class SAMUtils(QObject):
     def _load_model_blocking(self, model_name: str) -> None:
         # Lazy import keeps app startup fast for users who never use SAM.
         from ultralytics import SAM
+        from ..core.torch_utils import resolve_torch_device
+
+        self._device, _ = resolve_torch_device()
         self._log_device()
         model_file = os.path.join(SAM_MODELS_DIR, MODEL_FILES[model_name])
         os.makedirs(os.path.dirname(model_file), exist_ok=True)
         self._model = SAM(model_file)
         self._loaded_model_file = model_file
 
-    @staticmethod
-    def _log_device() -> None:
+    def _log_device(self) -> None:
         try:
             import torch
-            if torch.cuda.is_available():
+            if self._device == "cuda":
                 dev = torch.cuda.get_device_name(0)
                 print(f"[SAM] Using CUDA: {torch.version.cuda} — {dev}")
             else:
-                print("[SAM] No GPU available, running on CPU")
+                print("[SAM] Running on CPU")
         except Exception:
             pass
 
@@ -406,7 +409,9 @@ class SAMUtils(QObject):
     def _sam_points_blocking(self, image_np, positive_points, negative_points):
         all_points = [positive_points + negative_points]
         all_labels = [([1] * len(positive_points)) + ([0] * len(negative_points))]
-        results = self._model(image_np, points=all_points, labels=all_labels)
+        results = self._model(
+            image_np, points=all_points, labels=all_labels, device=self._device
+        )
 
         masks = results[0].masks.data.cpu().numpy()
         confidences = results[0].boxes.conf.cpu().numpy()
@@ -438,7 +443,7 @@ class SAMUtils(QObject):
         )
 
     def _sam_bbox_blocking(self, image_np, bbox):
-        results = self._model(image_np, bboxes=[bbox])
+        results = self._model(image_np, bboxes=[bbox], device=self._device)
         res = results[0]
         if not (hasattr(res, "masks") and res.masks is not None):
             return None
@@ -481,7 +486,7 @@ class SAMUtils(QObject):
         )
 
     def _sam_batch_blocking(self, image_np, bboxes):
-        results = self._model(image_np, bboxes=bboxes)
+        results = self._model(image_np, bboxes=bboxes, device=self._device)
         res = results[0]
         if not (hasattr(res, "masks") and res.masks is not None):
             # Build a fresh dict per bbox so callers can mutate one

--- a/src/digitalsreeni_image_annotator/io/export_formats.py
+++ b/src/digitalsreeni_image_annotator/io/export_formats.py
@@ -19,7 +19,7 @@ def convert_to_coco(all_annotations, class_mapping, image_paths, slices, image_s
     with tempfile.TemporaryDirectory() as temp_dir:
         json_file_path, images_dir = export_coco_json(all_annotations, class_mapping, image_paths, slices, image_slices, temp_dir)
         
-        with open(json_file_path, 'r') as f:
+        with open(json_file_path, 'r', encoding='utf-8') as f:
             coco_data = json.load(f)
         
     return coco_data, images_dir
@@ -118,7 +118,7 @@ def export_coco_json(all_annotations, class_mapping, image_paths, slices, image_
 
     # Save COCO JSON file
     json_file_path = os.path.join(output_dir, json_filename)
-    with open(json_file_path, 'w') as f:
+    with open(json_file_path, 'w', encoding='utf-8') as f:
         json.dump(coco_format, f, indent=2)
 
     return json_file_path, images_dir
@@ -205,7 +205,7 @@ def export_yolo_v4(all_annotations, class_mapping, image_paths, slices, image_sl
 
         # Write YOLO format annotation
         label_file = os.path.splitext(file_name_img)[0] + '.txt'
-        with open(os.path.join(labels_dir, label_file), 'w') as f:
+        with open(os.path.join(labels_dir, label_file), 'w', encoding='utf-8') as f:
             for class_name, class_annotations in annotations.items():
                 if class_name not in class_to_index:
                     print(f"[YOLO v4] warning: class {class_name!r} not in class_mapping, skipped")
@@ -236,7 +236,7 @@ def export_yolo_v4(all_annotations, class_mapping, image_paths, slices, image_sl
 
     # Save YAML file in the output directory
     yaml_path = os.path.join(output_dir, 'data.yaml')
-    with open(yaml_path, 'w') as f:
+    with open(yaml_path, 'w', encoding='utf-8') as f:
         yaml.dump(yaml_data, f, default_flow_style=False)
 
     return train_dir, yaml_path
@@ -280,7 +280,7 @@ def export_yolo_v5plus(all_annotations, class_mapping, image_paths, slices, imag
         print(f"[YOLO v5+]   image={image_name!r} annotation-classes={list(annotations.keys()) if annotations else '(none)'}")
         # Skip if there are no annotations for this image/slice
         if not annotations:
-            print(f"[YOLO v5+]     skipping: no annotations")
+            print("[YOLO v5+]     skipping: no annotations")
             continue
 
         # For simplicity, we'll put all data in the train directory
@@ -334,7 +334,7 @@ def export_yolo_v5plus(all_annotations, class_mapping, image_paths, slices, imag
         label_file = os.path.splitext(file_name_img)[0] + '.txt'
         label_path = os.path.join(labels_dir, label_file)
         ann_lines = 0
-        with open(label_path, 'w') as f:
+        with open(label_path, 'w', encoding='utf-8') as f:
             for class_name, class_annotations in annotations.items():
                 if class_name not in class_to_index:
                     print(f"[YOLO v5+]     warning: class {class_name!r} not in class_mapping, skipped")
@@ -372,7 +372,7 @@ def export_yolo_v5plus(all_annotations, class_mapping, image_paths, slices, imag
 
     # Save YAML file in the output directory
     yaml_path = os.path.join(output_dir, 'data.yaml')
-    with open(yaml_path, 'w') as f:
+    with open(yaml_path, 'w', encoding='utf-8') as f:
         yaml.dump(yaml_data, f, default_flow_style=False)
 
     return output_dir, yaml_path
@@ -477,7 +477,7 @@ def export_labeled_images(all_annotations, class_mapping, image_paths, slices, i
 
     # Create summary text file
     summary_path = os.path.join(labeled_images_dir, 'class_summary.txt')
-    with open(summary_path, 'w') as f:
+    with open(summary_path, 'w', encoding='utf-8') as f:
         f.write("Classes (folder names):\n")
         for class_name, files in class_summary.items():
             if files:  # Only include classes that have annotations
@@ -575,7 +575,7 @@ def export_semantic_labels(all_annotations, class_mapping, image_paths, slices, 
 
     # Create class mapping text file
     mapping_path = os.path.join(segmented_images_dir, 'class_pixel_mapping.txt')
-    with open(mapping_path, 'w') as f:
+    with open(mapping_path, 'w', encoding='utf-8') as f:
         f.write("Pixel Value : Class Name\n")
         for class_name, pixel_value in class_to_pixel.items():
             f.write(f"{pixel_value} : {class_name}\n")
@@ -680,7 +680,7 @@ def export_pascal_voc_bbox(all_annotations, class_mapping, image_paths, slices, 
         # Save the XML file
         xml_str = minidom.parseString(ET.tostring(root)).toprettyxml(indent="    ")
         xml_filename = os.path.splitext(file_name_img)[0] + '.xml'
-        with open(os.path.join(annotations_dir, xml_filename), 'w') as f:
+        with open(os.path.join(annotations_dir, xml_filename), 'w', encoding='utf-8') as f:
             f.write(xml_str)
     
     return output_dir         
@@ -798,7 +798,7 @@ def export_pascal_voc_both(all_annotations, class_mapping, image_paths, slices, 
         # Save the XML file
         xml_str = minidom.parseString(ET.tostring(root)).toprettyxml(indent="    ")
         xml_filename = os.path.splitext(file_name_img)[0] + '.xml'
-        with open(os.path.join(annotations_dir, xml_filename), 'w') as f:
+        with open(os.path.join(annotations_dir, xml_filename), 'w', encoding='utf-8') as f:
             f.write(xml_str)
 
     return output_dir

--- a/src/digitalsreeni_image_annotator/io/import_formats.py
+++ b/src/digitalsreeni_image_annotator/io/import_formats.py
@@ -4,17 +4,12 @@ import os
 import yaml
 from PIL import Image
 
-from PyQt6.QtCore import QRectF
-from PyQt6.QtGui import QColor
-from PyQt6.QtWidgets import QMessageBox, QFileDialog
-
-import os
-import json
 from PyQt6.QtWidgets import QMessageBox
+
 
 def import_coco_json(file_path, class_mapping):
     try:
-        with open(file_path, 'r') as f:
+        with open(file_path, 'r', encoding='utf-8') as f:
             coco_data = json.load(f)
 
         # Validate required fields
@@ -127,7 +122,7 @@ def import_yolo_v4(yaml_file_path, class_mapping):
     
     directory_path = os.path.dirname(yaml_file_path)
     
-    with open(yaml_file_path, 'r') as f:
+    with open(yaml_file_path, 'r', encoding='utf-8') as f:
         yaml_data = yaml.safe_load(f)
     
     class_names = yaml_data.get('names', [])
@@ -184,7 +179,7 @@ def import_yolo_v4(yaml_file_path, class_mapping):
             imported_annotations[img_file] = {}
             
             label_path = os.path.join(labels_dir, label_file)
-            with open(label_path, 'r') as f:
+            with open(label_path, 'r', encoding='utf-8') as f:
                 lines = f.readlines()
             
             for line in lines:
@@ -267,7 +262,7 @@ def import_yolo_v5plus(yaml_file_path, class_mapping):
     
     root_dir = os.path.dirname(yaml_file_path)
     
-    with open(yaml_file_path, 'r') as f:
+    with open(yaml_file_path, 'r', encoding='utf-8') as f:
         yaml_data = yaml.safe_load(f)
     
     class_names = yaml_data.get('names', [])
@@ -320,7 +315,7 @@ def import_yolo_v5plus(yaml_file_path, class_mapping):
                 imported_annotations[img_file] = {}
                 
                 label_path = os.path.join(labels_dir, label_file)
-                with open(label_path, 'r') as f:
+                with open(label_path, 'r', encoding='utf-8') as f:
                     lines = f.readlines()
                 
                 for line in lines:

--- a/src/digitalsreeni_image_annotator/ui/sidebar.py
+++ b/src/digitalsreeni_image_annotator/ui/sidebar.py
@@ -319,6 +319,20 @@ def build_image_list(window):
     window.image_list_label = QLabel("Images:")
     window.image_list_layout.addWidget(window.image_list_label)
 
+    # Annotation-status filter (upstream issue #27). Index order matters:
+    # ImageController.apply_image_filter maps 0=all, 1=without, 2=with.
+    window.image_filter_combo = QComboBox()
+    window.image_filter_combo.addItem("All images")
+    window.image_filter_combo.addItem("Without annotations")
+    window.image_filter_combo.addItem("With annotations")
+    window.image_filter_combo.setToolTip(
+        "Filter the image list by annotation status"
+    )
+    window.image_filter_combo.currentIndexChanged.connect(
+        lambda _index: window.apply_image_filter()
+    )
+    window.image_list_layout.addWidget(window.image_filter_combo)
+
     window.image_list = QListWidget()
     window.image_list.itemClicked.connect(window.switch_image)
     window.image_list.currentRowChanged.connect(

--- a/src/digitalsreeni_image_annotator/widgets/image_label.py
+++ b/src/digitalsreeni_image_annotator/widgets/image_label.py
@@ -29,6 +29,7 @@ from PyQt6.QtGui import (
 from PyQt6.QtWidgets import QLabel, QMessageBox
 
 from .tools import EraserTool, PaintBrushTool, PolygonTool, RectangleTool
+from ..utils import calculate_area
 
 warnings.filterwarnings("ignore", category=UserWarning)
 
@@ -848,6 +849,12 @@ class ImageLabel(QLabel):
         self.update()
 
     def start_polygon_edit(self, pos):
+        # Among all polygons containing the click, edit the smallest by
+        # area so an annotation fully nested inside another is reachable
+        # (upstream issue #33) instead of always grabbing the first/outer
+        # match.
+        best = None
+        best_area = None
         for class_name, annotations in self.annotations.items():
             for annotation in annotations:
                 if "segmentation" in annotation:
@@ -859,11 +866,16 @@ class ImageLabel(QLabel):
                         )
                     ]
                     if self.point_in_polygon(pos, points):
-                        self.editing_polygon = annotation
-                        self.current_tool = None
-                        self.disableToolsRequested.emit()
-                        self.resetToolButtonsRequested.emit()
-                        return annotation
+                        area = calculate_area(annotation)
+                        if best is None or area < best_area:
+                            best = annotation
+                            best_area = area
+        if best is not None:
+            self.editing_polygon = best
+            self.current_tool = None
+            self.disableToolsRequested.emit()
+            self.resetToolButtonsRequested.emit()
+            return best
         return None
 
     def handle_editing_click(self, pos, event):

--- a/tests/integration/test_image_filter_wiring.py
+++ b/tests/integration/test_image_filter_wiring.py
@@ -1,0 +1,87 @@
+"""
+Integration test for the image-filter re-apply wiring (upstream #27).
+
+The unit tests call apply_image_filter() directly; this test goes through
+the real mutation path instead: ImageLabel.annotationsBatchSaved →
+ImageAnnotator._on_annotations_batch_saved → save_current_annotations →
+ClassController.update_slice_list_colors → apply_image_filter. It is the
+test that fails if someone refactors the slice-color path and silently
+detaches the filter from annotation mutations.
+
+Constructs one full ImageAnnotator (offscreen) — deliberately, despite
+the runtime cost, because the coupling under test spans window, signals
+and three controllers.
+"""
+
+import pytest
+
+
+FILTER_WITHOUT = 1  # combo index: "Without annotations"
+FILTER_WITH = 2  # combo index: "With annotations"
+
+
+@pytest.fixture
+def window(qt_application):
+    from digitalsreeni_image_annotator.annotator_window import ImageAnnotator
+
+    w = ImageAnnotator()
+    yield w
+    w.deleteLater()
+
+
+def test_annotation_commit_path_reapplies_filter(window):
+    # Two regular images, neither annotated yet. currentRow stays -1 so
+    # the "never hide current row" exemption doesn't mask the assertion.
+    for name in ("a.png", "b.png"):
+        window.all_images.append({"file_name": name, "is_multi_slice": False})
+        window.image_list.addItem(name)
+
+    window.image_filter_combo.setCurrentIndex(FILTER_WITH)
+    assert window.image_list.isRowHidden(0)
+    assert window.image_list.isRowHidden(1)
+
+    # Simulate finishing an annotation on a.png the way the canvas does:
+    # ImageLabel holds the in-progress annotations and emits the batch
+    # finalizer signal. No direct apply_image_filter / all_annotations
+    # manipulation here — that's the point of the test.
+    window.image_file_name = "a.png"
+    window.image_label.annotations = {
+        "cell": [{"segmentation": [0, 0, 10, 0, 10, 10], "category_name": "cell"}]
+    }
+    window.image_label.annotationsBatchSaved.emit()
+
+    assert window.all_annotations["a.png"]  # save path ran
+    assert not window.image_list.isRowHidden(0)  # a.png now annotated
+    assert window.image_list.isRowHidden(1)  # b.png still hidden
+
+
+def test_hiding_current_row_keeps_canvas_and_fires_no_switch(window):
+    # Hiding the currently selected (non-matching) row must not change
+    # the displayed image or fire switch_image — the canvas stays on the
+    # worked-on image while its row leaves the list.
+    for name in ("annot.png", "plain.png"):
+        window.all_images.append({"file_name": name, "is_multi_slice": False})
+        window.image_list.addItem(name)
+    window.all_annotations["annot.png"] = {
+        "cell": [{"segmentation": [0, 0, 1, 0, 1, 1], "category_name": "cell"}]
+    }
+
+    # Pure counter (does NOT delegate to the real switch_image, which
+    # needs a loaded project): isolates whether the *filter* fires a
+    # switch. setCurrentRow below legitimately fires it once via
+    # currentRowChanged — that is product behavior and is cleared away.
+    calls = []
+    window.switch_image = lambda item: calls.append(item)
+
+    window.image_list.setCurrentRow(0)  # select the annotated image
+    sentinel = object()
+    window.current_image = sentinel
+    calls.clear()
+
+    # "Without annotations" must hide row 0 even though it is current.
+    window.image_filter_combo.setCurrentIndex(FILTER_WITHOUT)
+
+    assert window.image_list.isRowHidden(0)  # current row hidden
+    assert not window.image_list.isRowHidden(1)
+    assert window.current_image is sentinel  # canvas unchanged
+    assert calls == []  # hiding the current row fired no switch_image

--- a/tests/integration/test_smoke.py
+++ b/tests/integration/test_smoke.py
@@ -47,6 +47,7 @@ INTERNAL_MODULES = [
     # Core helpers
     "digitalsreeni_image_annotator.core.constants",
     "digitalsreeni_image_annotator.core.annotation_utils",
+    "digitalsreeni_image_annotator.core.torch_utils",
     # UI
     "digitalsreeni_image_annotator.ui.default_stylesheet",
     "digitalsreeni_image_annotator.ui.soft_dark_stylesheet",

--- a/tests/unit/test_image_filter.py
+++ b/tests/unit/test_image_filter.py
@@ -1,0 +1,149 @@
+"""
+Unit tests for the image-list annotation-status filter (upstream issue #27).
+
+Covers ImageController.image_has_annotations and apply_image_filter.
+"""
+
+import pytest
+from PyQt6.QtWidgets import QWidget, QListWidget, QComboBox
+
+from src.digitalsreeni_image_annotator.controllers.image_controller import (
+    ImageController,
+)
+
+
+FILTER_ALL = 0
+FILTER_WITHOUT = 1
+FILTER_WITH = 2
+
+
+class FakeMainWindow(QWidget):
+    """Minimal stand-in for ImageAnnotator with the state the filter reads."""
+
+
+@pytest.fixture
+def mw(qtbot):
+    window = FakeMainWindow()
+    qtbot.addWidget(window)
+    window.image_list = QListWidget(window)
+    window.image_filter_combo = QComboBox(window)
+    window.image_filter_combo.addItems(
+        ["All images", "Without annotations", "With annotations"]
+    )
+    window.all_images = []
+    window.all_annotations = {}
+    window.image_slices = {}
+    window.image_controller = ImageController(window)
+    return window
+
+
+def _add_image(mw, file_name, is_multi_slice=False):
+    mw.all_images.append(
+        {"file_name": file_name, "is_multi_slice": is_multi_slice}
+    )
+    mw.image_list.addItem(file_name)
+
+
+class TestImageHasAnnotations:
+    def test_regular_image_without_annotations(self, mw):
+        _add_image(mw, "plain.png")
+        assert not mw.image_controller.image_has_annotations(mw.all_images[0])
+
+    def test_regular_image_with_empty_class_lists(self, mw):
+        _add_image(mw, "plain.png")
+        mw.all_annotations["plain.png"] = {"cell": []}
+        assert not mw.image_controller.image_has_annotations(mw.all_images[0])
+
+    def test_regular_image_with_annotations(self, mw):
+        _add_image(mw, "plain.png")
+        mw.all_annotations["plain.png"] = {
+            "cell": [{"segmentation": [0, 0, 1, 0, 1, 1]}]
+        }
+        assert mw.image_controller.image_has_annotations(mw.all_images[0])
+
+    def test_multi_slice_with_annotated_slice(self, mw):
+        _add_image(mw, "stack.tif", is_multi_slice=True)
+        mw.image_slices["stack"] = [("stack_T1_Z1", None), ("stack_T1_Z2", None)]
+        mw.all_annotations["stack_T1_Z2"] = {
+            "cell": [{"segmentation": [0, 0, 1, 0, 1, 1]}]
+        }
+        assert mw.image_controller.image_has_annotations(mw.all_images[0])
+
+    def test_multi_slice_without_annotated_slices(self, mw):
+        _add_image(mw, "stack.tif", is_multi_slice=True)
+        mw.image_slices["stack"] = [("stack_T1_Z1", None)]
+        mw.all_annotations["stack_T1_Z1"] = {"cell": []}
+        assert not mw.image_controller.image_has_annotations(mw.all_images[0])
+
+    def test_multi_slice_prefix_fallback_when_slices_not_loaded(self, mw):
+        # Project annotations exist under slice keys, but the slices were
+        # never extracted (e.g. load cancelled) — prefix fallback applies.
+        _add_image(mw, "stack.tif", is_multi_slice=True)
+        mw.all_annotations["stack_T1_Z5_C1"] = {
+            "cell": [{"segmentation": [0, 0, 1, 0, 1, 1]}]
+        }
+        assert mw.image_controller.image_has_annotations(mw.all_images[0])
+
+    def test_multi_slice_no_substring_false_positive(self, mw):
+        # "bee" must not match keys of "honeybee" (and vice versa).
+        _add_image(mw, "bee.tif", is_multi_slice=True)
+        mw.all_annotations["honeybee_T1_Z1"] = {
+            "cell": [{"segmentation": [0, 0, 1, 0, 1, 1]}]
+        }
+        assert not mw.image_controller.image_has_annotations(mw.all_images[0])
+
+
+class TestApplyImageFilter:
+    @pytest.fixture
+    def populated(self, mw):
+        _add_image(mw, "annotated.png")
+        _add_image(mw, "empty.png")
+        mw.all_annotations["annotated.png"] = {
+            "cell": [{"segmentation": [0, 0, 1, 0, 1, 1]}]
+        }
+        # Select the annotated image so the "never hide current" rule is
+        # exercised by a dedicated test, not by accident here.
+        mw.image_list.setCurrentRow(-1)
+        return mw
+
+    def _hidden(self, mw):
+        return [
+            mw.image_list.isRowHidden(i) for i in range(mw.image_list.count())
+        ]
+
+    def test_all_images_shows_everything(self, populated):
+        populated.image_filter_combo.setCurrentIndex(FILTER_ALL)
+        populated.image_controller.apply_image_filter()
+        assert self._hidden(populated) == [False, False]
+
+    def test_without_annotations_hides_annotated(self, populated):
+        populated.image_filter_combo.setCurrentIndex(FILTER_WITHOUT)
+        populated.image_controller.apply_image_filter()
+        assert self._hidden(populated) == [True, False]
+
+    def test_with_annotations_hides_unannotated(self, populated):
+        populated.image_filter_combo.setCurrentIndex(FILTER_WITH)
+        populated.image_controller.apply_image_filter()
+        assert self._hidden(populated) == [False, True]
+
+    def test_current_row_is_hidden_when_not_matching(self, populated):
+        # The current row is not exempt: a non-matching selected image
+        # leaves the list (the canvas keeps showing it — see the wiring
+        # test for the switch_image / canvas-unchanged guarantee).
+        populated.image_list.setCurrentRow(0)  # annotated.png
+        populated.image_filter_combo.setCurrentIndex(FILTER_WITHOUT)
+        populated.image_controller.apply_image_filter()
+        assert self._hidden(populated) == [True, False]
+
+    def test_no_combo_is_a_noop(self, mw):
+        _add_image(mw, "plain.png")
+        del mw.image_filter_combo
+        mw.image_controller.apply_image_filter()  # must not raise
+        assert not mw.image_list.isRowHidden(0)
+
+    def test_switching_back_to_all_unhides(self, populated):
+        populated.image_filter_combo.setCurrentIndex(FILTER_WITH)
+        populated.image_controller.apply_image_filter()
+        populated.image_filter_combo.setCurrentIndex(FILTER_ALL)
+        populated.image_controller.apply_image_filter()
+        assert self._hidden(populated) == [False, False]

--- a/tests/unit/test_image_list_sort.py
+++ b/tests/unit/test_image_list_sort.py
@@ -1,0 +1,113 @@
+"""
+Unit tests for alphabetical image-list sorting (upstream issue #60).
+
+sort_image_list must order the list case-insensitively, keep the
+all_images model aligned with the list rows (positional invariant used
+by COCO import), and never fire a spurious switch_image.
+"""
+
+import pytest
+from PyQt6.QtWidgets import QWidget, QListWidget, QComboBox
+
+from src.digitalsreeni_image_annotator.controllers.image_controller import (
+    ImageController,
+)
+
+
+class FakeMainWindow(QWidget):
+    pass
+
+
+@pytest.fixture
+def mw(qtbot):
+    window = FakeMainWindow()
+    qtbot.addWidget(window)
+    window.image_list = QListWidget(window)
+    window.image_filter_combo = QComboBox(window)
+    window.image_filter_combo.addItems(
+        ["All images", "Without annotations", "With annotations"]
+    )
+    window.all_images = []
+    window.all_annotations = {}
+    window.image_slices = {}
+    window.image_paths = {}
+    window.is_loading_project = False
+    window.auto_save = lambda: None
+    window.image_controller = ImageController(window)
+    return window
+
+
+def _populate(mw, names):
+    # Populate out of order, mimicking the model+view pairing that
+    # add_images_to_list produces before a sort.
+    for n in names:
+        mw.all_images.append({"file_name": n, "is_multi_slice": False})
+        mw.image_list.addItem(n)
+
+
+def _list_texts(mw):
+    return [mw.image_list.item(i).text() for i in range(mw.image_list.count())]
+
+
+def test_sorts_alphabetically(mw):
+    _populate(mw, ["banana.png", "apple.png", "cherry.png"])
+    mw.image_controller.sort_image_list()
+    assert _list_texts(mw) == ["apple.png", "banana.png", "cherry.png"]
+
+
+def test_sort_is_case_insensitive(mw):
+    _populate(mw, ["Zebra.png", "apple.png", "Banana.png"])
+    mw.image_controller.sort_image_list()
+    assert _list_texts(mw) == ["apple.png", "Banana.png", "Zebra.png"]
+
+
+def test_model_and_view_stay_aligned(mw):
+    _populate(mw, ["d.png", "a.png", "c.png", "b.png"])
+    mw.image_controller.sort_image_list()
+    assert _list_texts(mw) == [info["file_name"] for info in mw.all_images]
+
+
+def test_sort_fires_no_switch_image(mw):
+    _populate(mw, ["b.png", "a.png"])
+    calls = []
+    mw.switch_image = lambda item: calls.append(item)
+    mw.image_controller.switch_image = lambda item: calls.append(item)
+    mw.image_list.setCurrentRow(0)
+    calls.clear()
+    mw.image_controller.sort_image_list()  # no select_name, do_switch=False
+    assert calls == []
+
+
+def test_selection_preserved_across_sort(mw):
+    _populate(mw, ["b.png", "a.png", "c.png"])
+    mw.image_list.setCurrentRow(0)  # b.png
+    mw.image_controller.sort_image_list()
+    assert mw.image_list.currentItem().text() == "b.png"
+
+
+def test_select_name_and_switch(mw):
+    _populate(mw, ["b.png", "a.png"])
+    calls = []
+    mw.switch_image = lambda item: calls.append(item.text())
+    mw.image_controller.switch_image = lambda item: calls.append(item.text())
+    mw.image_controller.sort_image_list(select_name="a.png", do_switch=True)
+    assert mw.image_list.currentItem().text() == "a.png"
+    assert calls == ["a.png"]
+
+
+def test_project_load_path_ends_sorted(mw):
+    # Contract: during project load add_images_to_list does NOT sort per
+    # image (avoids O(n^2)); the list is rebuilt once afterwards via the
+    # update_ui -> update_image_list call. This guards a refactor of that
+    # call from silently leaving the post-load list unsorted.
+    mw.is_loading_project = True
+    mw.image_controller.add_images_to_list(["c.png", "a.png", "b.png"])
+    # Not populated/sorted yet while loading.
+    assert mw.image_list.count() == 0
+
+    mw.is_loading_project = False
+    mw.image_controller.update_image_list()  # what update_ui triggers
+
+    texts = [mw.image_list.item(i).text() for i in range(mw.image_list.count())]
+    assert texts == ["a.png", "b.png", "c.png"]
+    assert texts == [info["file_name"] for info in mw.all_images]

--- a/tests/unit/test_polygon_edit.py
+++ b/tests/unit/test_polygon_edit.py
@@ -1,0 +1,71 @@
+"""
+Unit tests for nested-polygon edit selection (upstream issue #33).
+
+start_polygon_edit must enter edit mode on the *smallest* polygon that
+contains the click, so an annotation fully nested inside another is
+reachable instead of always grabbing the outer one.
+"""
+
+import pytest
+
+from src.digitalsreeni_image_annotator.widgets.image_label import ImageLabel
+
+
+@pytest.fixture
+def label(qtbot):
+    lbl = ImageLabel(None)
+    qtbot.addWidget(lbl)
+    return lbl
+
+
+def _square(x0, y0, side, name):
+    return {
+        "segmentation": [x0, y0, x0 + side, y0, x0 + side, y0 + side, x0, y0 + side],
+        "category_name": name,
+    }
+
+
+@pytest.fixture
+def nested(label):
+    outer = _square(0, 0, 100, "outer")      # area 10000
+    inner = _square(40, 40, 20, "inner")     # area 400, fully inside outer
+    # Insert outer first so the old "return first match" behavior would
+    # have returned outer — the test fails unless smallest-area wins.
+    label.annotations = {"cell": [outer, inner]}
+    return label, outer, inner
+
+
+def test_click_in_nested_region_selects_inner(nested):
+    label, outer, inner = nested
+    result = label.start_polygon_edit((50, 50))  # inside both
+    assert result is inner
+    assert label.editing_polygon is inner
+
+
+def test_click_only_in_outer_selects_outer(nested):
+    label, outer, inner = nested
+    result = label.start_polygon_edit((10, 10))  # inside outer only
+    assert result is outer
+    assert label.editing_polygon is outer
+
+
+def test_click_outside_all_returns_none(nested):
+    label, outer, inner = nested
+    label.editing_polygon = None
+    result = label.start_polygon_edit((500, 500))
+    assert result is None
+
+
+def test_insertion_order_does_not_matter(label):
+    # Inner listed first: result must still be the smallest, not the first.
+    outer = _square(0, 0, 100, "outer")
+    inner = _square(40, 40, 20, "inner")
+    label.annotations = {"cell": [inner, outer]}
+    assert label.start_polygon_edit((50, 50)) is inner
+
+
+def test_bbox_only_annotation_is_ignored(label):
+    # start_polygon_edit only handles "segmentation"; bbox editing is #40.
+    bbox_ann = {"bbox": [0, 0, 100, 100], "category_name": "box"}
+    label.annotations = {"cell": [bbox_ann]}
+    assert label.start_polygon_edit((50, 50)) is None

--- a/tests/unit/test_tiff_codec.py
+++ b/tests/unit/test_tiff_codec.py
@@ -1,0 +1,86 @@
+"""
+Unit tests for graceful handling of compressed TIFFs missing imagecodecs
+(upstream issue #56).
+
+An LZW TIFF read raises ValueError when imagecodecs is absent; the app
+must skip the file with a dialog instead of crashing, and must not leave
+a half-added entry.
+"""
+
+import pytest
+from PyQt6.QtWidgets import QWidget, QListWidget, QComboBox
+
+import src.digitalsreeni_image_annotator.controllers.image_controller as ic_module
+from src.digitalsreeni_image_annotator.controllers.image_controller import (
+    ImageController,
+)
+
+LZW_ERROR = "<COMPRESSION.LZW: 5> requires the 'imagecodecs' package"
+
+
+class FakeMainWindow(QWidget):
+    pass
+
+
+@pytest.fixture
+def mw(qtbot):
+    window = FakeMainWindow()
+    qtbot.addWidget(window)
+    window.image_list = QListWidget(window)
+    window.image_filter_combo = QComboBox(window)
+    window.image_filter_combo.addItems(
+        ["All images", "Without annotations", "With annotations"]
+    )
+    window.all_images = []
+    window.all_annotations = {}
+    window.image_slices = {}
+    window.image_paths = {}
+    window.is_loading_project = False
+    window.auto_save = lambda: None
+    window.image_controller = ImageController(window)
+    return window
+
+
+def test_lzw_tiff_without_codec_is_skipped_with_dialog(mw, monkeypatch):
+    dialogs = []
+    monkeypatch.setattr(
+        ic_module.QMessageBox, "critical",
+        lambda *a, **k: dialogs.append(a),
+    )
+
+    def raise_lzw(_path):
+        raise ValueError(LZW_ERROR)
+
+    mw.image_controller.load_multi_slice_image = raise_lzw
+
+    # Must not raise.
+    mw.image_controller.add_images_to_list(["C:/data/scan.tif"])
+
+    assert len(dialogs) == 1          # one critical dialog shown
+    assert mw.all_images == []        # no half-added entry
+    assert mw.image_list.count() == 0
+    assert "scan.tif" not in mw.image_paths
+
+
+def test_is_missing_codec_error_matches():
+    assert ImageController._is_missing_codec_error(ValueError(LZW_ERROR))
+    assert ImageController._is_missing_codec_error(
+        ValueError("requires the 'imagecodecs' package")
+    )
+    # A bare "compression" mention must NOT match — that would swallow
+    # unrelated errors behind a misleading "install imagecodecs" dialog.
+    assert not ImageController._is_missing_codec_error(
+        ValueError("unsupported compression scheme")
+    )
+
+
+def test_unrelated_value_error_is_reraised(mw, monkeypatch):
+    monkeypatch.setattr(ic_module.QMessageBox, "critical", lambda *a, **k: None)
+
+    def raise_other(_path):
+        raise ValueError("corrupt dimension metadata")
+
+    mw.image_controller.load_multi_slice_image = raise_other
+
+    with pytest.raises(ValueError, match="corrupt dimension metadata"):
+        mw.image_controller.add_images_to_list(["C:/data/scan.tif"])

--- a/tests/unit/test_torch_utils.py
+++ b/tests/unit/test_torch_utils.py
@@ -1,0 +1,128 @@
+"""
+Unit tests for core.torch_utils device resolution (upstream issue #57).
+
+A fake `torch` module is injected into sys.modules so the tests run the
+same on machines with and without CUDA.
+"""
+
+import sys
+import types
+
+import pytest
+
+from src.digitalsreeni_image_annotator.core import torch_utils
+
+
+@pytest.fixture(autouse=True)
+def reset_cache():
+    torch_utils._cached_result = None
+    torch_utils._warning_shown = False
+    yield
+    torch_utils._cached_result = None
+    torch_utils._warning_shown = False
+
+
+@pytest.fixture
+def fake_torch(monkeypatch):
+    """Install a configurable fake torch module; returns its cuda namespace."""
+    cuda = types.SimpleNamespace(
+        is_available=lambda: False,
+        get_device_capability=lambda idx=0: (8, 6),
+        get_arch_list=lambda: ["sm_70", "sm_80", "sm_90", "compute_90"],
+        get_device_name=lambda idx=0: "Fake GPU",
+    )
+    module = types.ModuleType("torch")
+    module.cuda = cuda
+    monkeypatch.setitem(sys.modules, "torch", module)
+    return cuda
+
+
+def test_no_cuda_returns_cpu_without_warning(fake_torch):
+    assert torch_utils.resolve_torch_device() == ("cpu", None)
+
+
+def test_supported_gpu_returns_cuda(fake_torch):
+    fake_torch.is_available = lambda: True
+    assert torch_utils.resolve_torch_device() == ("cuda", None)
+
+
+def test_unsupported_pascal_gpu_falls_back_to_cpu(fake_torch):
+    fake_torch.is_available = lambda: True
+    fake_torch.get_device_capability = lambda idx=0: (6, 1)  # GTX 1050
+    device, warning = torch_utils.resolve_torch_device()
+    assert device == "cpu"
+    assert "sm_61" in warning
+    assert "sm_70" in warning
+    assert "Fake GPU" in warning
+
+
+def test_oldest_supported_capability_is_accepted(fake_torch):
+    fake_torch.is_available = lambda: True
+    fake_torch.get_device_capability = lambda idx=0: (7, 0)
+    assert torch_utils.resolve_torch_device() == ("cuda", None)
+
+
+def test_empty_arch_list_keeps_cuda(fake_torch):
+    # Defensive: if torch reports no compiled arches, don't second-guess it.
+    fake_torch.is_available = lambda: True
+    fake_torch.get_arch_list = lambda: []
+    assert torch_utils.resolve_torch_device() == ("cuda", None)
+
+
+def test_probe_failure_falls_back_to_cpu(fake_torch):
+    fake_torch.is_available = lambda: True
+
+    def boom(idx=0):
+        raise RuntimeError("driver mismatch")
+
+    fake_torch.get_device_capability = boom
+    device, warning = torch_utils.resolve_torch_device()
+    assert device == "cpu"
+    assert "driver mismatch" in warning
+
+
+def test_missing_torch_returns_cpu(monkeypatch):
+    monkeypatch.setitem(sys.modules, "torch", None)  # import torch → fails
+    assert torch_utils.resolve_torch_device() == ("cpu", None)
+
+
+def test_result_is_cached(fake_torch):
+    fake_torch.is_available = lambda: True
+    assert torch_utils.resolve_torch_device() == ("cuda", None)
+    # Changing the fake afterwards must not change the cached decision.
+    fake_torch.is_available = lambda: False
+    assert torch_utils.resolve_torch_device() == ("cuda", None)
+
+
+def test_parse_arch_list():
+    assert torch_utils._parse_arch_list(
+        ["sm_70", "sm_80", "compute_90", "garbage", "sm_xx"]
+    ) == [70, 80]
+
+
+def test_warning_dialog_shown_once(fake_torch, monkeypatch, qt_application):
+    fake_torch.is_available = lambda: True
+    fake_torch.get_device_capability = lambda idx=0: (6, 1)
+
+    calls = []
+    from PyQt6.QtWidgets import QMessageBox
+    monkeypatch.setattr(
+        QMessageBox, "warning", lambda *a, **k: calls.append(a)
+    )
+
+    torch_utils.maybe_warn_cpu_fallback(None)
+    torch_utils.maybe_warn_cpu_fallback(None)
+    assert len(calls) == 1
+
+
+def test_no_warning_dialog_when_device_ok(fake_torch, monkeypatch, qt_application):
+    fake_torch.is_available = lambda: True
+
+    calls = []
+    from PyQt6.QtWidgets import QMessageBox
+    monkeypatch.setattr(
+        QMessageBox, "warning", lambda *a, **k: calls.append(a)
+    )
+
+    torch_utils.maybe_warn_cpu_fallback(None)
+    assert calls == []

--- a/tests/unit/test_yaml_encoding.py
+++ b/tests/unit/test_yaml_encoding.py
@@ -1,0 +1,33 @@
+"""
+Regression guard for UTF-8 file encoding (upstream issue #44).
+
+Reading a COCO JSON that contains non-ASCII category names must succeed
+regardless of the platform's default code page. Before the fix, open()
+without encoding used cp1252 on Windows and crashed on these bytes. The
+test writes genuine non-ASCII bytes (ensure_ascii=False) and asserts the
+unicode survives the round-trip through import_coco_json's open().
+"""
+
+import json
+
+from src.digitalsreeni_image_annotator.io.import_formats import import_coco_json
+
+UNICODE_CLASS = "Zellkörper-Ü-中"  # German + a CJK char
+
+
+def test_import_coco_json_preserves_unicode_class(tmp_path):
+    coco = {
+        "images": [{"id": 1, "file_name": "img.png", "width": 10, "height": 10}],
+        "categories": [{"id": 1, "name": UNICODE_CLASS}],
+        "annotations": [
+            {"id": 1, "image_id": 1, "category_id": 1, "bbox": [0, 0, 5, 5]}
+        ],
+    }
+    json_path = tmp_path / "annotations.json"
+    with open(json_path, "w", encoding="utf-8") as f:
+        json.dump(coco, f, ensure_ascii=False)
+
+    imported_annotations, image_info = import_coco_json(str(json_path), {})
+
+    assert UNICODE_CLASS in imported_annotations["img.png"]
+    assert image_info[1]["file_name"] == "img.png"


### PR DESCRIPTION
Hi @bnsreenu — five small, independent fixes for open issues. Each is scoped and tested.

> **Note:** this PR is **stacked on #71** (#27 image filter + #57 CPU fallback). #60 and #56 build on the image-list filter work from #71, so please **merge #71 first** — after that, this PR's diff narrows to just the five quick wins below. Until then the diff also shows #71's changes.

## Closes #30 — YOLO save_model crash
`self.model.export(save_path)` converts to a deployment format and fails on a `.pt` path; switched to `self.model.save(save_path)` (reporter-verified in the issue).

## Closes #44 — Windows 'charmap' codec crash
Added `encoding='utf-8'` to every text-mode `open()` across YAML/JSON/TXT — YOLO config/labels, COCO import/export, dataset splitter, augmenter, combiner, DINO merge, DICOM metadata, project search, and the `.iap` project save/load. Non-ASCII class names and paths no longer crash on the cp1252 default. PIL `Image.open` (binary) left untouched.

## Closes #33 — can't edit nested annotation
`start_polygon_edit` now picks the **smallest** polygon containing the double-click (reusing the existing shoelace `calculate_area`), so an annotation fully inside another is reachable. bbox-only editing remains separate (that's #40).

## Closes #60 — sort image list alphabetically
New `ImageController.sort_image_list` orders `all_images` and the list widget together with signals blocked — deliberately **not** `setSortingEnabled`, since `currentRowChanged` is wired to `switch_image` and a live re-sort would fire spurious image switches. Preserves the `all_images[i]` ↔ `image_list.item(i)` invariant the COCO importer relies on; skipped per-image during project load to avoid O(n²).

## Closes #56 — LZW TIFF crash
Added `imagecodecs` to `install_requires` (fixes fresh installs) and catch the codec `ValueError` in `add_images_to_list`: show an actionable "pip install imagecodecs" dialog and skip the file instead of crashing or leaving a half-added entry. Non-codec ValueErrors still propagate.

## Testing
- 157 tests pass (16 new for these fixes: nested-polygon selection, sort model/view alignment + no-spurious-switch + load-path ordering, codec-error handling, UTF-8 round-trip).
- `ruff check --select F,E9` clean on touched files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)